### PR TITLE
feat(sql-mysql): add a native MySQL client

### DIFF
--- a/.changeset/add-native-mysql-client.md
+++ b/.changeset/add-native-mysql-client.md
@@ -1,0 +1,26 @@
+---
+"@effect/sql-mysql": patch
+---
+
+Add `@effect/sql-mysql`, a MySQL client that speaks the protocol directly instead of wrapping a driver. It has no runtime dependencies — `node:net` and `node:tls` are the only transport — and requires MySQL 8.0 or newer.
+
+Authentication covers `caching_sha2_password` (the MySQL 8 default, including the RSA key exchange that full authentication needs on a plaintext socket), `sha256_password`, `mysql_native_password`, and `mysql_clear_password` for accounts backed by PAM, LDAP or Kerberos. The last of those sends the password unprotected, so it is refused unless the connection is encrypted.
+
+It sits alongside `@effect/sql-mysql2`, which is unchanged. The two share the `SqlClient` contract, so switching is a change of layer:
+
+```ts
+import { MysqlClient } from "@effect/sql-mysql"
+
+const layer = MysqlClient.layer({ url: Redacted.make("mysql://user:pass@localhost:3306/app") })
+```
+
+Behaviour that differs from `@effect/sql-mysql2` and is worth checking before you switch:
+
+- `BIGINT` decodes to `bigint` rather than a number, and `DECIMAL` to a string, so neither is silently rounded. `bigintAsNumber: true` restores the lossy convenience. Note that a bare integer literal is a `BIGINT` in MySQL, so `` sql`SELECT 1` `` yields `1n`.
+- `DATETIME` and `TIMESTAMP` decode to epoch milliseconds, and `TIME` to signed microseconds, since `TIME` is a duration spanning -838:59:59 to 838:59:59 rather than a clock reading. `dateStrings: true` returns strings instead.
+- The session time zone is set to UTC on connect, which is what makes temporal decoding deterministic rather than dependent on the server's zone. Override it with `timezone`.
+- `BLOB` and `TEXT` are told apart by the column's collation, so binary columns yield `Uint8Array` and text columns yield `string`.
+- Errors are classified from the server's ERR packet rather than from a driver exception: the error number is consulted first and the SQLSTATE class second, so errors the table does not name still land in the right family.
+- `LOAD DATA LOCAL INFILE` is refused: the capability is not negotiated, so a server requesting one is treated as a protocol violation.
+
+Also included: `MysqlMigrator`, whose `mysqldump` schema dump is implemented rather than pending a `Command` module, and which passes the password through `MYSQL_PWD` rather than argv.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -35,6 +35,7 @@
       "@effect/sql-d1",
       "@effect/sql-libsql",
       "@effect/sql-mssql",
+      "@effect/sql-mysql",
       "@effect/sql-mysql2",
       "@effect/sql-pg",
       "@effect/sql-pglite",

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This monorepo contains the core `effect` package alongside integration packages 
 | [`@effect/sql-d1`](packages/sql/d1)                                   | SQL client for Cloudflare D1                             | [docs](https://effect.website/docs/v4/api/sql-d1)                  |
 | [`@effect/sql-libsql`](packages/sql/libsql)                           | SQL client for libSQL                                    | [docs](https://effect.website/docs/v4/api/sql-libsql)              |
 | [`@effect/sql-mssql`](packages/sql/mssql)                             | SQL client for Microsoft SQL Server                      | [docs](https://effect.website/docs/v4/api/sql-mssql)               |
+| [`@effect/sql-mysql`](packages/sql/mysql)                             | SQL client for MySQL, native protocol                    | [docs](https://effect.website/docs/v4/api/sql-mysql)               |
 | [`@effect/sql-mysql2`](packages/sql/mysql2)                           | SQL client for MySQL                                     | [docs](https://effect.website/docs/v4/api/sql-mysql2)              |
 | [`@effect/sql-pg`](packages/sql/pg)                                   | SQL client for PostgreSQL                                | [docs](https://effect.website/docs/v4/api/sql-pg)                  |
 | [`@effect/sql-pglite`](packages/sql/pglite)                           | SQL client for [PGlite](https://pglite.dev)              | [docs](https://effect.website/docs/v4/api/sql-pglite)              |

--- a/packages/sql/mysql/LICENSE
+++ b/packages/sql/mysql/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-present The Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/sql/mysql/README.md
+++ b/packages/sql/mysql/README.md
@@ -1,0 +1,18 @@
+# @effect/sql-mysql
+
+An Effect SQL client for MySQL, speaking the MySQL client/server protocol
+directly. It has no runtime dependencies — `node:net` and `node:tls` are the
+only transport.
+
+Requires MySQL 8.0 or newer.
+
+## Installation
+
+```sh
+npm install effect@rc @effect/sql-mysql@rc
+```
+
+## Documentation
+
+- [Effect website](https://effect.website)
+- [API reference](https://effect.website/docs/v4/api/sql-mysql)

--- a/packages/sql/mysql/benchmark/MysqlClient.ts
+++ b/packages/sql/mysql/benchmark/MysqlClient.ts
@@ -1,0 +1,75 @@
+import { MysqlClient } from "@effect/sql-mysql"
+import { MysqlClient as Mysql2Client } from "@effect/sql-mysql2"
+import { MySqlContainer } from "@testcontainers/mysql"
+import * as Effect from "effect/Effect"
+import * as Redacted from "effect/Redacted"
+import * as Reactivity from "effect/unstable/reactivity/Reactivity"
+import type { SqlClient } from "effect/unstable/sql/SqlClient"
+import { Bench } from "tinybench"
+
+const rowCount = 100
+
+const seed = (sql: SqlClient) =>
+  Effect.gen(function*() {
+    yield* sql`DROP TABLE IF EXISTS bench`
+    yield* sql`CREATE TABLE bench (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(64), n INT, flag TINYINT)`
+    yield* sql`SET SESSION cte_max_recursion_depth = ${rowCount + 1}`
+    yield* sql`
+      INSERT INTO bench (name, n, flag) WITH RECURSIVE seq(x) AS (
+        SELECT 1 UNION ALL SELECT x + 1 FROM seq WHERE x < ${rowCount}
+      ) SELECT CONCAT('row-', x), x, x % 2 FROM seq
+    `.unprepared
+  })
+
+/** The workloads each client runs, so both are measured on the same shapes. */
+const workloads = (sql: SqlClient): Record<string, () => Promise<unknown>> => ({
+  "one row": () => Effect.runPromise(sql`SELECT id, name, n, flag FROM bench WHERE id = ${1}`),
+  [`${rowCount} rows`]: () => Effect.runPromise(sql`SELECT id, name, n, flag FROM bench`),
+  "transaction": () => Effect.runPromise(sql.withTransaction(sql`SELECT id FROM bench WHERE id = ${1}`)),
+  "20 concurrent": () =>
+    Effect.runPromise(Effect.all(
+      Array.from({ length: 20 }, (_, index) => sql`SELECT id, name FROM bench WHERE id = ${index + 1}`),
+      { concurrency: "unbounded" }
+    ))
+})
+
+const program = (uri: string) =>
+  Effect.gen(function*() {
+    const url = Redacted.make(uri)
+    const clients: ReadonlyArray<readonly [string, SqlClient]> = [
+      ["@effect/sql-mysql", yield* MysqlClient.make({ url, maxConnections: 10 })],
+      ["@effect/sql-mysql2", yield* Mysql2Client.make({ url, maxConnections: 10 })]
+    ]
+
+    yield* seed(clients[0][1])
+
+    const bench = new Bench({ time: 2000 })
+    for (const [name, sql] of clients) {
+      for (const [workload, task] of Object.entries(workloads(sql))) {
+        bench.add(`${workload} — ${name}`, task)
+      }
+    }
+
+    // Warm the pools and the statement caches so the first sample is not the
+    // one that pays for connecting.
+    for (const [, sql] of clients) {
+      for (const task of Object.values(workloads(sql))) {
+        yield* Effect.promise(task)
+      }
+    }
+
+    yield* Effect.promise(() => bench.run())
+    console.table(bench.table())
+  }).pipe(Effect.scoped, Effect.provide(Reactivity.layer))
+
+const uri = process.env.MYSQLCLIENT_BENCHMARK_URL
+if (uri !== undefined) {
+  await Effect.runPromise(program(uri))
+} else {
+  const container = await new MySqlContainer("mysql:8.4").start()
+  try {
+    await Effect.runPromise(program(container.getConnectionUri()))
+  } finally {
+    await container.stop()
+  }
+}

--- a/packages/sql/mysql/benchmark/MysqlCodec.ts
+++ b/packages/sql/mysql/benchmark/MysqlCodec.ts
@@ -1,0 +1,86 @@
+import { MysqlProtocol, MysqlTypes } from "@effect/sql-mysql"
+import * as Result from "effect/Result"
+import { Bench } from "tinybench"
+
+const success = <A, E>(result: Result.Result<A, E>): A => {
+  if (Result.isFailure(result)) throw result.failure
+  return result.success
+}
+
+const write = (run: Parameters<typeof MysqlProtocol.encodeWith>[0]): Uint8Array =>
+  success(MysqlProtocol.encodeWith(run))
+
+/** A column definition, built the way the server would send one. */
+const column = (name: string, type: number, collation = MysqlProtocol.defaultCollation) =>
+  success(MysqlProtocol.decodeColumn(write((w) => {
+    w.lenencString("def")
+    w.lenencString("bench")
+    w.lenencString("rows")
+    w.lenencString("rows")
+    w.lenencString(name)
+    w.lenencString(name)
+    w.lenencInt(0x0c)
+    w.uint16(collation)
+    w.uint32(255)
+    w.uint8(type)
+    w.uint16(0)
+    w.uint8(0)
+    w.fill(0, 2)
+  })))
+
+const columns = [
+  column("id", MysqlProtocol.ColumnType.longlong),
+  column("name", MysqlProtocol.ColumnType.varString),
+  column("n", MysqlProtocol.ColumnType.long),
+  column("flag", MysqlProtocol.ColumnType.tiny)
+]
+
+const rowCount = 100
+
+/** The text-protocol payloads for one hundred rows. */
+const payloads = Array.from({ length: rowCount }, (_, index) =>
+  write((w) => {
+    w.lenencString(String(index + 1))
+    w.lenencString(`row-${index + 1}`)
+    w.lenencString(String(index + 1))
+    w.lenencString(String(index % 2))
+  }))
+
+const readField = MysqlTypes.makeTextFieldReader(columns)
+
+const toRow = (values: ReadonlyArray<unknown>): Record<string, unknown> => {
+  const row: Record<string, unknown> = {}
+  for (let index = 0; index < columns.length; index++) row[columns[index].name] = values[index]
+  return row
+}
+
+/** Classify, decode and build one hundred rows, with no Effect and no socket. */
+const decodeRows = (): Array<Record<string, unknown>> => {
+  const rows: Array<Record<string, unknown>> = []
+  for (let index = 0; index < payloads.length; index++) {
+    const packet = success(MysqlProtocol.decodeRow(payloads[index]))
+    if (!MysqlProtocol.RowPacket.$is("Row")(packet)) continue
+    rows.push(toRow(success(MysqlProtocol.decodeTextRow(packet.payload, columns.length, readField))))
+  }
+  return rows
+}
+
+/** The same without the packet classification, to price that separately. */
+const decodeRowsWithoutClassify = (): Array<Record<string, unknown>> => {
+  const rows: Array<Record<string, unknown>> = []
+  for (let index = 0; index < payloads.length; index++) {
+    rows.push(toRow(success(MysqlProtocol.decodeTextRow(payloads[index], columns.length, readField))))
+  }
+  return rows
+}
+
+const sanity = decodeRows()
+if (sanity.length !== rowCount || sanity[0].name !== "row-1" || sanity[0].id !== 1n) {
+  throw new Error(`Decoded rows are wrong: ${JSON.stringify(sanity[0])}`)
+}
+
+const bench = new Bench({ time: 2000 })
+bench.add(`decode ${rowCount} rows`, decodeRows)
+bench.add(`decode ${rowCount} rows, no classification`, decodeRowsWithoutClassify)
+await bench.run()
+console.table(bench.table())

--- a/packages/sql/mysql/benchmark/README.md
+++ b/packages/sql/mysql/benchmark/README.md
@@ -1,0 +1,48 @@
+# MySQL benchmarks
+
+## MysqlClient
+
+`MysqlClient.ts` measures complete queries through the client, including Effect execution, pool checkout, the MySQL
+wire protocol, and result decoding, and runs the same workloads through `@effect/sql-mysql2` for comparison. It covers
+a parameterized one-row query, a 100-row result, a single-statement transaction, and 20 concurrent queries through a
+ten-connection pool. The transaction is there because `BEGIN`, `COMMIT`, and the savepoint statements reach the
+connection through a different path from the statements between them, so a change to that path is invisible to every
+other workload here.
+
+A MySQL Testcontainer starts automatically, so a container runtime is the only external requirement.
+
+Run it from the repository root:
+
+```sh
+pnpm --filter @effect/sql-mysql benchmark:client
+```
+
+To use an existing MySQL server instead, set `MYSQLCLIENT_BENCHMARK_URL` to its connection URI. Keep the same server,
+Node version, and machine load when comparing revisions.
+
+Two numbers from different machines are not comparable, and on anything but Linux the container is usually the reason:
+the server runs inside a virtual machine on macOS and Windows, so every round trip crosses a virtualised network, and
+the workloads that wait on one — the single-row query and the transaction — measure that boundary as much as they
+measure the client.
+
+## Where the time goes
+
+Measured on macOS against the container, so treat the absolute numbers as
+machine-local. Against `@effect/sql-mysql2`, this client is ahead on the
+single-row query (1.06x), the transaction (1.04x) and 20 concurrent queries
+(1.04x), and behind on the 100-row read (0.85x).
+
+The 100-row gap is the only one worth explaining, and it is not decode.
+`MysqlCodec.ts` puts decoding a 100-row result at about 21us against a whole
+query of about 195us — roughly a ninth of it — and a CPU profile of the same
+workload is 86% idle, with this package accounting for under a seventh of the
+active time. The client is waiting, not computing.
+
+What is left is per-row rather than per-query: the single-row query costs
+about 131us and the 100-row query about 195us, so the marginal row costs this
+client roughly 0.65us against `mysql2`'s 0.27us. A result set of 100 rows is
+100 packets, and each one is handed from the parser to the reply reader
+through a queue, so the most likely candidate is that handoff rather than any
+single expensive step. That is a hypothesis with a number attached, not a
+finding: it has not been isolated, and a previous attempt to attribute the gap
+to per-row Effect steps was measured and disproved.

--- a/packages/sql/mysql/package.json
+++ b/packages/sql/mysql/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@effect/sql-mysql",
+  "version": "4.0.0-rc.115",
+  "type": "module",
+  "license": "MIT",
+  "description": "A native MySQL toolkit for Effect",
+  "homepage": "https://effect.website",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Effect-TS/effect.git",
+    "directory": "packages/sql/mysql"
+  },
+  "bugs": {
+    "url": "https://github.com/Effect-TS/effect/issues"
+  },
+  "tags": [
+    "typescript",
+    "sql",
+    "database"
+  ],
+  "keywords": [
+    "typescript",
+    "sql",
+    "database"
+  ],
+  "sideEffects": [],
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts",
+    "./internal/*": null,
+    "./index": null,
+    "./*/index": null
+  },
+  "files": [
+    "src/**/*.ts",
+    "dist/**/*.js",
+    "dist/**/*.js.map",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map",
+    "AGENTS.md",
+    "CLAUDE.md",
+    "ai-docs/**/*"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./dist/index.js",
+      "./*": "./dist/*.js",
+      "./internal/*": null,
+      "./index": null,
+      "./*/index": null
+    }
+  },
+  "scripts": {
+    "benchmark:codec": "node benchmark/MysqlCodec.ts",
+    "benchmark:client": "node benchmark/MysqlClient.ts",
+    "codegen": "effect-utils codegen",
+    "build": "tsc -b tsconfig.json && pnpm babel",
+    "babel": "babel dist --plugins annotate-pure-calls --out-dir dist --source-maps",
+    "check": "tsc -b tsconfig.json"
+  },
+  "devDependencies": {
+    "@effect/platform-node": "workspace:^",
+    "@effect/sql-mysql2": "workspace:^",
+    "@testcontainers/mysql": "^12.1.0",
+    "@types/node": "^26.4.1",
+    "effect": "workspace:^",
+    "tinybench": "^6.1.6"
+  },
+  "peerDependencies": {
+    "effect": "workspace:^"
+  }
+}

--- a/packages/sql/mysql/src/MysqlAuth.ts
+++ b/packages/sql/mysql/src/MysqlAuth.ts
@@ -1,0 +1,289 @@
+/**
+ * Authentication plugin computations for the MySQL handshake.
+ *
+ * Every function here is pure: it takes a password and the server's challenge
+ * and returns the bytes to send back. Nothing here reads a socket, and nothing
+ * here generates randomness — the scramble always comes from the server.
+ *
+ * Two plugins are implemented. `mysql_native_password` is the legacy SHA-1
+ * exchange. `caching_sha2_password` is the MySQL 8 default: it first tries a
+ * fast exchange against the server's password cache, and on a cache miss falls
+ * back to full authentication, which needs either a TLS connection or an RSA
+ * key exchange because the server has to see the password itself.
+ *
+ * @since 4.0.0
+ */
+import * as Data from "effect/Data"
+import * as Result from "effect/Result"
+import * as crypto from "node:crypto"
+
+/**
+ * A failure computing an authentication response.
+ *
+ * @category errors
+ * @since 4.0.0
+ */
+export class AuthError extends Data.TaggedError("MysqlAuthError")<{
+  readonly message: string
+}> {}
+
+/**
+ * The length of the scramble the server sends in its handshake.
+ *
+ * @category constants
+ * @since 4.0.0
+ */
+export const scrambleLength = 20
+
+/**
+ * Status bytes the server sends in an `AuthMoreData` packet during a
+ * `caching_sha2_password` exchange.
+ *
+ * @category constants
+ * @since 4.0.0
+ */
+export const CachingSha2 = {
+  /** The password matched the server's cache; the next packet is the OK. */
+  fastAuthSuccess: 0x03,
+  /** The cache missed; the client must complete full authentication. */
+  fullAuthRequired: 0x04,
+  /** Sent by the client to ask for the server's RSA public key. */
+  requestPublicKey: 0x02
+} as const
+
+/**
+ * Bytes the `sha256_password` exchange uses.
+ *
+ * **Gotchas**
+ *
+ * It asks for the server's public key with a different byte than
+ * `caching_sha2_password` does, and has no fast path: the server never holds a
+ * cached verdict for it.
+ *
+ * @category constants
+ * @since 4.0.0
+ */
+export const Sha256 = {
+  /** Sent by the client to ask for the server's RSA public key. */
+  requestPublicKey: 0x01
+} as const
+
+const digest = (algorithm: string, ...parts: ReadonlyArray<Uint8Array>): Uint8Array => {
+  const hash = crypto.createHash(algorithm)
+  for (const part of parts) hash.update(part)
+  return new Uint8Array(hash.digest())
+}
+
+const xorInto = (target: Uint8Array, mask: Uint8Array): Uint8Array => {
+  for (let index = 0; index < target.length; index++) {
+    target[index] ^= mask[index % mask.length]
+  }
+  return target
+}
+
+const result = <A>(evaluate: () => A): Result.Result<A, AuthError> => {
+  try {
+    return Result.succeed(evaluate())
+  } catch (error) {
+    if (error instanceof AuthError) return Result.fail(error)
+    return Result.fail(new AuthError({ message: error instanceof Error ? error.message : String(error) }))
+  }
+}
+
+const requireScramble = (scramble: Uint8Array): Uint8Array => {
+  if (scramble.length !== scrambleLength) {
+    throw new AuthError({ message: `Expected a ${scrambleLength}-byte scramble, got ${scramble.length}` })
+  }
+  return scramble
+}
+
+const passwordBytes = (password: string): Uint8Array => new Uint8Array(Buffer.from(password, "utf8"))
+
+/**
+ * Computes a `mysql_native_password` response.
+ *
+ * **Details**
+ *
+ * The response is `SHA1(password)` XOR `SHA1(scramble || SHA1(SHA1(password)))`,
+ * which lets the server verify the password from the `SHA1(SHA1(password))` it
+ * stores without ever seeing the password. An empty password sends no bytes at
+ * all.
+ *
+ * @category authentication
+ * @since 4.0.0
+ */
+export const nativePassword = (options: {
+  readonly password: string
+  readonly scramble: Uint8Array
+}): Result.Result<Uint8Array, AuthError> =>
+  result(() => {
+    if (options.password.length === 0) return new Uint8Array(0)
+    const scramble = requireScramble(options.scramble)
+    const stage1 = digest("sha1", passwordBytes(options.password))
+    const stage2 = digest("sha1", stage1)
+    return xorInto(stage1, digest("sha1", scramble, stage2))
+  })
+
+/**
+ * Computes the fast-path `caching_sha2_password` response, the one sent in the
+ * initial handshake response.
+ *
+ * **Details**
+ *
+ * The response is `SHA256(password)` XOR
+ * `SHA256(SHA256(SHA256(password)) || scramble)`. The server answers with
+ * `fastAuthSuccess` when its cache already holds the password, and
+ * `fullAuthRequired` when it does not.
+ *
+ * @category authentication
+ * @since 4.0.0
+ */
+export const cachingSha2Password = (options: {
+  readonly password: string
+  readonly scramble: Uint8Array
+}): Result.Result<Uint8Array, AuthError> =>
+  result(() => {
+    if (options.password.length === 0) return new Uint8Array(0)
+    const scramble = requireScramble(options.scramble)
+    const stage1 = digest("sha256", passwordBytes(options.password))
+    const stage2 = digest("sha256", stage1)
+    return xorInto(stage1, digest("sha256", stage2, scramble))
+  })
+
+/**
+ * Produces the cleartext password to send during full `caching_sha2_password`
+ * authentication over a TLS connection.
+ *
+ * **Gotchas**
+ *
+ * The password is NUL-terminated and otherwise unprotected, so this must only
+ * ever be written to an encrypted socket. Use `encryptedPassword` on a
+ * plaintext connection.
+ *
+ * @category authentication
+ * @since 4.0.0
+ */
+export const cleartextPassword = (password: string): Uint8Array => {
+  const bytes = passwordBytes(password)
+  const out = new Uint8Array(bytes.length + 1)
+  out.set(bytes)
+  return out
+}
+
+/**
+ * Encrypts the password for full `caching_sha2_password` authentication over a
+ * plaintext connection, using the RSA public key the server supplied.
+ *
+ * **Details**
+ *
+ * The NUL-terminated password is first XOR'd with the scramble, repeated
+ * cyclically, so a captured ciphertext cannot be replayed against a different
+ * handshake. The result is encrypted with OAEP padding.
+ *
+ * @category authentication
+ * @since 4.0.0
+ */
+export const encryptedPassword = (options: {
+  readonly password: string
+  readonly scramble: Uint8Array
+  /** The server's public key, as the PEM text of its `AuthMoreData` packet. */
+  readonly publicKey: string
+  /** The OAEP digest. MySQL's default is SHA-1. */
+  readonly oaepHash?: string | undefined
+}): Result.Result<Uint8Array, AuthError> =>
+  result(() => {
+    const scramble = requireScramble(options.scramble)
+    const obfuscated = xorInto(cleartextPassword(options.password), scramble)
+    return new Uint8Array(crypto.publicEncrypt({
+      key: options.publicKey,
+      padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+      oaepHash: options.oaepHash ?? "sha1"
+    }, obfuscated))
+  })
+
+/**
+ * Computes the response for a named authentication plugin.
+ *
+ * **Details**
+ *
+ * This covers the initial handshake response and an `AuthSwitchRequest`, both
+ * of which name a plugin and supply a scramble. Full `caching_sha2_password`
+ * authentication is not reachable from here: it is driven by `AuthMoreData`
+ * packets that arrive afterwards.
+ *
+ * @category authentication
+ * @since 4.0.0
+ */
+export type Reply = Data.TaggedEnum<{
+  /** Bytes that answer the server's challenge. */
+  readonly Respond: { readonly bytes: Uint8Array }
+  /**
+   * Bytes that ask for the server's RSA public key. The reply to those is the
+   * key itself rather than a verdict, so the exchange has one more step.
+   */
+  readonly RequestPublicKey: { readonly bytes: Uint8Array }
+}>
+
+/**
+ * Constructors and guards for `Reply`.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export const Reply = Data.taggedEnum<Reply>()
+
+/**
+ * Answers a plugin's challenge.
+ *
+ * **Details**
+ *
+ * This covers the initial handshake response and an `AuthSwitchRequest`, both
+ * of which name a plugin and supply a scramble. Whether the connection is
+ * encrypted decides what the SHA-256 plugins may send: over TLS they hand the
+ * password over as it is, and otherwise they ask for a key to encrypt it with.
+ *
+ * @category authentication
+ * @since 4.0.0
+ */
+export const respond = (options: {
+  readonly plugin: string
+  readonly password: string
+  readonly scramble: Uint8Array
+  readonly usingTls: boolean
+}): Result.Result<Reply, AuthError> => {
+  const respondWith = (result: Result.Result<Uint8Array, AuthError>) =>
+    Result.map(result, (bytes) => Reply.Respond({ bytes }))
+  switch (options.plugin) {
+    case "mysql_native_password":
+      return respondWith(nativePassword(options))
+    case "caching_sha2_password":
+      return respondWith(cachingSha2Password(options))
+    case "sha256_password": {
+      // No cached verdict exists for this plugin, so the password has to reach
+      // the server on the first attempt, one way or the other.
+      if (options.usingTls || options.password.length === 0) {
+        return Result.succeed(Reply.Respond({ bytes: cleartextPassword(options.password) }))
+      }
+      return Result.succeed(
+        Reply.RequestPublicKey({ bytes: new Uint8Array([Sha256.requestPublicKey]) })
+      )
+    }
+    case "mysql_clear_password": {
+      // The server asks for this when the account is backed by PAM, LDAP or
+      // Kerberos, which need the password itself. It travels unprotected, so
+      // there is no safe version of it on a plaintext socket.
+      if (!options.usingTls) {
+        return Result.fail(
+          new AuthError({
+            message: "mysql_clear_password sends the password in the clear and requires TLS"
+          })
+        )
+      }
+      return Result.succeed(Reply.Respond({ bytes: cleartextPassword(options.password) }))
+    }
+    default:
+      return Result.fail(
+        new AuthError({ message: `Unsupported authentication plugin "${options.plugin}"` })
+      )
+  }
+}

--- a/packages/sql/mysql/src/MysqlClient.ts
+++ b/packages/sql/mysql/src/MysqlClient.ts
@@ -1,0 +1,388 @@
+/**
+ * MySQL support for Effect SQL, backed by the native wire protocol client.
+ *
+ * @since 4.0.0
+ */
+import type * as Arr from "effect/Array"
+import * as Config from "effect/Config"
+import * as Context from "effect/Context"
+import type * as Duration from "effect/Duration"
+import * as Effect from "effect/Effect"
+import * as Layer from "effect/Layer"
+import type * as Scope from "effect/Scope"
+import * as Stream from "effect/Stream"
+import * as Reactivity from "effect/unstable/reactivity/Reactivity"
+import * as Client from "effect/unstable/sql/SqlClient"
+import type { Borrower, Connection } from "effect/unstable/sql/SqlConnection"
+import { SqlError, UnknownError } from "effect/unstable/sql/SqlError"
+import type { Custom, Fragment } from "effect/unstable/sql/Statement"
+import * as Statement from "effect/unstable/sql/Statement"
+import { resolveAddress } from "./internal/config.ts"
+import { bindParameters } from "./internal/escape.ts"
+import * as MysqlConnection from "./MysqlConnection.ts"
+import * as MysqlPool from "./MysqlPool.ts"
+
+/**
+ * The runtime type identifier for `MysqlClient`.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export const TypeId: TypeId = "~@effect/sql-mysql/MysqlClient"
+
+/**
+ * The type-level identifier for `MysqlClient`.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export type TypeId = "~@effect/sql-mysql/MysqlClient"
+
+/**
+ * A MySQL `SqlClient` with a JSON helper.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export interface MysqlClient extends Client.SqlClient {
+  readonly [TypeId]: TypeId
+  readonly config: MysqlClientConfig
+  readonly json: (_: unknown) => Fragment
+}
+
+/**
+ * The service tag for `MysqlClient`.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const MysqlClient = Context.Service<MysqlClient>("@effect/sql-mysql/MysqlClient")
+
+/**
+ * Connection and query settings for a MySQL client.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface MysqlClientConfig extends MysqlConnection.Config {
+  readonly spanAttributes?: Record<string, unknown> | undefined
+  readonly transformResultNames?: ((str: string) => string) | undefined
+  readonly transformQueryNames?: ((str: string) => string) | undefined
+}
+
+/**
+ * MySQL client settings with connection pool limits and timeouts.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface MysqlPoolConfig extends MysqlClientConfig {
+  readonly idleTimeout?: Duration.Input | undefined
+  readonly maxConnections?: number | undefined
+  readonly minConnections?: number | undefined
+  readonly connectionTTL?: Duration.Input | undefined
+}
+
+/**
+ * Creates a scoped MySQL client backed by a connection pool.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const make = (
+  options: MysqlPoolConfig
+): Effect.Effect<MysqlClient, SqlError, Scope.Scope | Reactivity.Reactivity> => {
+  const prepare = options.prepare !== false
+  return Effect.flatMap(MysqlPool.make(options), (pool) =>
+    makeImpl({
+      acquirer: Effect.map(pool.get, (connection) => makeConnection(connection, prepare)),
+      borrower: (f) => pool.use((connection) => f(makeConnection(connection, prepare))),
+      transactionAcquirer: Effect.map(pool.get, (connection) => makeConnection(connection, prepare)),
+      config: options
+    }))
+}
+
+/**
+ * Creates a scoped MySQL client backed by one connection.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const makeClient = (
+  options: MysqlClientConfig
+): Effect.Effect<MysqlClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
+  Effect.flatMap(MysqlConnection.make(options), (connection) => {
+    const acquirer = Effect.succeed(makeConnection(connection, options.prepare !== false))
+    return makeImpl({ acquirer, transactionAcquirer: acquirer, config: options })
+  })
+
+const makeImpl = Effect.fnUntraced(function*(
+  options: {
+    readonly acquirer: Effect.Effect<Connection, SqlError, Scope.Scope>
+    readonly borrower?: Borrower | undefined
+    readonly transactionAcquirer: Effect.Effect<Connection, SqlError, Scope.Scope>
+    readonly config: MysqlClientConfig
+  }
+): Effect.fn.Return<MysqlClient, SqlError, Scope.Scope | Reactivity.Reactivity> {
+  const config = options.config
+  const address = resolveAddress(config)
+  const compiler = makeCompiler(config.transformQueryNames)
+  const transformRows = config.transformResultNames
+    ? Statement.defaultTransforms(config.transformResultNames).array
+    : undefined
+
+  return Object.assign(
+    yield* Client.make({
+      acquirer: options.acquirer,
+      borrower: options.borrower,
+      // MySQL cannot prepare BEGIN, START TRANSACTION or any of the savepoint
+      // statements. COMMIT and ROLLBACK it can, but the setting is all or
+      // nothing, so transaction control goes out on the text protocol.
+      prepareTransactionControls: false,
+      transactionAcquirer: options.transactionAcquirer,
+      compiler,
+      spanAttributes: [
+        ...(config.spanAttributes ? Object.entries(config.spanAttributes) : []),
+        [ATTR_DB_SYSTEM_NAME, "mysql"],
+        [ATTR_SERVER_ADDRESS, address.host],
+        [ATTR_SERVER_PORT, address.port],
+        ...(address.database === undefined ? [] : [[ATTR_DB_NAMESPACE, address.database] as const])
+      ],
+      transformRows
+    }),
+    {
+      [TypeId]: TypeId as TypeId,
+      config,
+      json: (_: unknown) => Statement.fragment([MysqlJson(_)])
+    }
+  )
+})
+
+const bindError = (cause: unknown): SqlError =>
+  new SqlError({
+    reason: new UnknownError({
+      cause,
+      message: "MysqlClient: Failed to bind statement parameters",
+      operation: "execute"
+    })
+  })
+
+/**
+ * The text protocol carries a finished statement, so parameters are written
+ * into the SQL here. Prepared statements bind them out of band instead.
+ */
+const bind = (sql: string, params: ReadonlyArray<unknown>): Effect.Effect<string, SqlError> =>
+  params.length === 0
+    ? Effect.succeed(sql)
+    : Effect.try({ try: () => bindParameters(sql, params), catch: bindError })
+
+/**
+ * The counters of a statement that returned no rows, named as the `mysql2`
+ * client names them.
+ *
+ * **Details**
+ *
+ * This is what a multi-statement request yields for each statement that
+ * produced no result set — see `Shaped`. A single statement does not produce
+ * one: `.raw` surfaces the connection's own `Result`, whose equivalent fields
+ * are `lastInsertId` and `warnings`.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface OkHeader {
+  readonly affectedRows: number | bigint
+  readonly insertId: number | bigint
+  readonly warningStatus: number
+}
+
+/**
+ * What one entry of a shaped reply can be: the rows of a result set, one row,
+ * or the header of a statement that produced none.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type Shaped = MysqlConnection.Row | ReadonlyArray<MysqlConnection.Row> | OkHeader
+
+/**
+ * Shapes a command's results the way the `mysql2` client does, which is what
+ * `SqlModel` reads: one result set returns its rows, one OK packet returns no
+ * rows, and several statements return one entry each.
+ */
+const shape = (results: ReadonlyArray<MysqlConnection.Result>): ReadonlyArray<Shaped> => {
+  if (results.length === 0) return []
+  if (results.length === 1) return MysqlConnection.Result.rowsOf(results[0])
+  return results.map((result): Shaped =>
+    MysqlConnection.Result.$match(result, {
+      ResultSet: ({ rows }) => rows,
+      Ok: ({ affectedRows, lastInsertId, warnings }) => ({
+        affectedRows,
+        insertId: lastInsertId,
+        warningStatus: warnings
+      })
+    })
+  )
+}
+
+class ConnectionImpl implements Connection {
+  readonly connection: MysqlConnection.MysqlConnection
+  /** Whether the default path prepares, or falls back to the text protocol. */
+  readonly prepare: boolean
+
+  constructor(connection: MysqlConnection.MysqlConnection, prepare: boolean) {
+    this.connection = connection
+    this.prepare = prepare
+  }
+
+  /** The text protocol, where parameters are written into the statement. */
+  private textResults(sql: string, params: ReadonlyArray<unknown>) {
+    return Effect.flatMap(bind(sql, params), (text) => this.connection.query(text))
+  }
+
+  private results(sql: string, params: ReadonlyArray<unknown>) {
+    return this.prepare ? this.connection.execute(sql, params) : this.textResults(sql, params)
+  }
+
+  private run(sql: string, params: ReadonlyArray<unknown>) {
+    return Effect.map(this.results(sql, params), shape)
+  }
+
+  execute(
+    sql: string,
+    params: ReadonlyArray<unknown>,
+    transformRows: (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined
+  ) {
+    return transformRows ? Effect.map(this.run(sql, params), transformRows) : this.run(sql, params)
+  }
+  executeRaw(sql: string, params: ReadonlyArray<unknown>) {
+    return Effect.map(this.results(sql, params), (results) => results.length === 1 ? results[0] : results)
+  }
+  executeValues(sql: string, params: ReadonlyArray<unknown>) {
+    return this.prepare
+      ? this.connection.executeValues(sql, params)
+      : this.executeValuesUnprepared(sql, params)
+  }
+  executeValuesUnprepared(sql: string, params: ReadonlyArray<unknown>) {
+    return Effect.flatMap(bind(sql, params), (text) => this.connection.queryValues(text))
+  }
+  executeUnprepared(
+    sql: string,
+    params: ReadonlyArray<unknown>,
+    transformRows: (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined
+  ) {
+    const operation = Effect.map(this.textResults(sql, params), shape)
+    return transformRows ? Effect.map(operation, transformRows) : operation
+  }
+  executeStream(
+    sql: string,
+    params: ReadonlyArray<unknown>,
+    transformRows: (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined
+  ) {
+    const stream = this.connection.stream(sql, params)
+    return transformRows
+      ? Stream.mapArray(stream, (rows) => transformRows(rows) as Arr.NonEmptyReadonlyArray<MysqlConnection.Row>)
+      : stream
+  }
+}
+
+const makeConnection = (
+  connection: MysqlConnection.MysqlConnection,
+  prepare: boolean
+): Connection => new ConnectionImpl(connection, prepare)
+
+/**
+ * Provides both `MysqlClient` and `SqlClient` from an acquisition effect.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layerFrom = <E, R>(
+  acquire: Effect.Effect<MysqlClient, E, R>
+): Layer.Layer<MysqlClient | Client.SqlClient, E, Exclude<R, Scope.Scope | Reactivity.Reactivity>> =>
+  Layer.effectContext(
+    Effect.map(acquire, (client) =>
+      Context.make(MysqlClient, client).pipe(
+        Context.add(Client.SqlClient, client)
+      ))
+  ).pipe(Layer.provide(Reactivity.layer)) as any
+
+/**
+ * Creates a client layer from wrapped pool configuration.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layerConfig = (
+  config: Config.Wrap<MysqlPoolConfig>
+): Layer.Layer<MysqlClient | Client.SqlClient, Config.ConfigError | SqlError> =>
+  layerFrom(Effect.flatMap(Config.unwrap(config), make))
+
+/**
+ * Creates a client layer from pool configuration.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layer = (
+  config: MysqlPoolConfig
+): Layer.Layer<MysqlClient | Client.SqlClient, SqlError> => layerFrom(make(config))
+
+/**
+ * Creates the MySQL statement compiler.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const makeCompiler = (transform?: (_: string) => string): Statement.Compiler => {
+  const transformValue = transform ? Statement.defaultTransforms(transform).value : undefined
+  return Statement.makeCompiler<MysqlCustom>({
+    dialect: "mysql",
+    placeholder() {
+      return `?`
+    },
+    onIdentifier: transform ?
+      function(value, withoutTransform) {
+        return withoutTransform ? escape(value) : escape(transform(value))
+      } :
+      escape,
+    onCustom(type, placeholder, withoutTransform) {
+      switch (type.kind) {
+        case "MysqlJson": {
+          const value = withoutTransform || transformValue === undefined ? type.paramA : transformValue(type.paramA)
+          return [placeholder(undefined), [JSON.stringify(value)]]
+        }
+      }
+    },
+    // MySQL has no multi-row update form, so `sql.updateValues` compiles away.
+    onRecordUpdate() {
+      return ["", []]
+    }
+  })
+}
+
+const escape = Statement.defaultEscape("`")
+
+/**
+ * MySQL-specific statement fragments.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type MysqlCustom = MysqlJson
+
+/**
+ * @category models
+ * @since 4.0.0
+ */
+interface MysqlJson extends Custom<"MysqlJson", unknown> {}
+/**
+ * @category constructors
+ * @since 4.0.0
+ */
+const MysqlJson = Statement.custom<MysqlJson>("MysqlJson")
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name"
+const ATTR_DB_NAMESPACE = "db.namespace"
+const ATTR_SERVER_ADDRESS = "server.address"
+const ATTR_SERVER_PORT = "server.port"

--- a/packages/sql/mysql/src/MysqlConnection.ts
+++ b/packages/sql/mysql/src/MysqlConnection.ts
@@ -1,0 +1,1393 @@
+/**
+ * Native MySQL sessions built on the `MysqlProtocol` wire codec.
+ *
+ * A session owns one socket. It negotiates capabilities, authenticates, and
+ * runs one command at a time: MySQL numbers every packet within a command and
+ * has no equivalent of the sync points that let a PostgreSQL connection
+ * pipeline, so commands are serialized on the wire rather than interleaved.
+ *
+ * @since 4.0.0
+ */
+import * as Cause from "effect/Cause"
+import * as Context from "effect/Context"
+import * as Data from "effect/Data"
+import * as Duration from "effect/Duration"
+import * as Effect from "effect/Effect"
+import * as Queue from "effect/Queue"
+import * as Redacted from "effect/Redacted"
+import * as EffectResult from "effect/Result"
+import type * as Scope from "effect/Scope"
+import * as Semaphore from "effect/Semaphore"
+import * as Stream from "effect/Stream"
+import { AuthenticationError, ConnectionError, SqlError } from "effect/unstable/sql/SqlError"
+import * as SqlStream from "effect/unstable/sql/SqlStream"
+import * as Net from "node:net"
+import type { Duplex } from "node:stream"
+import * as Tls from "node:tls"
+import type { ConnectionOptions } from "node:tls"
+import { configError, parseUrl, type UrlConfig } from "./internal/config.ts"
+import { type ConnectionInternals, internalsKey } from "./internal/connection.ts"
+import { bindParameters as bindText } from "./internal/escape.ts"
+import {
+  binaryRows,
+  Completed,
+  decodedAs,
+  drainReply,
+  makeReader,
+  type PacketReader,
+  type Prepared,
+  readAcknowledgement,
+  readPrepared,
+  readReply,
+  readStream,
+  type RowDecoder,
+  type Take,
+  take,
+  textRows
+} from "./internal/reply.ts"
+import { classifyErr, connectionError, queryError } from "./internal/sqlError.ts"
+import * as MysqlAuth from "./MysqlAuth.ts"
+import * as MysqlProtocol from "./MysqlProtocol.ts"
+import * as MysqlTypes from "./MysqlTypes.ts"
+
+/**
+ * The runtime type identifier for `MysqlConnection`.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export const TypeId: TypeId = "~@effect/sql-mysql/MysqlConnection"
+
+/**
+ * The type-level identifier for `MysqlConnection`.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export type TypeId = "~@effect/sql-mysql/MysqlConnection"
+
+/**
+ * Connection settings for a MySQL session.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface Config {
+  /**
+   * A `mysql://` connection string. The fields below override whatever it
+   * carries, so a URL can supply the defaults and an option correct one.
+   */
+  readonly url?: Redacted.Redacted | undefined
+
+  /** Defaults to `localhost`. */
+  readonly host?: string | undefined
+  /** Defaults to `3306`. */
+  readonly port?: number | undefined
+  /** A Unix domain socket path, used in place of `host` and `port`. */
+  readonly path?: string | undefined
+  /**
+   * Upgrades the connection to TLS. Off by default, which is why
+   * `mysql_clear_password` is refused unless this is set.
+   */
+  readonly ssl?: boolean | ConnectionOptions | undefined
+  readonly database?: string | undefined
+  /** Falls back to the `USER` or `USERNAME` environment variable. */
+  readonly username?: string | undefined
+  readonly password?: Redacted.Redacted | undefined
+
+  /** How long the socket and handshake have to complete. Defaults to 5s. */
+  readonly connectTimeout?: Duration.Input | undefined
+
+  /**
+   * Supplies the transport, in place of opening a socket. Use it for a proxy
+   * or a cloud connector that hands back an already-routed duplex stream.
+   */
+  readonly stream?: (() => Duplex) | undefined
+
+  /**
+   * The session time zone, set once the connection is established. Defaults to
+   * `+00:00`, which makes `DATETIME` and `TIMESTAMP` decode deterministically
+   * rather than following the server's zone.
+   */
+  readonly timezone?: string | undefined
+
+  /**
+   * Decodes `BIGINT` as a `number` rather than a `bigint`. Convenient, and
+   * lossy above 2^53, so it is off by default.
+   */
+  readonly bigintAsNumber?: boolean | undefined
+
+  /**
+   * Decodes `DATETIME`, `TIMESTAMP` and `TIME` as strings rather than as epoch
+   * milliseconds and microsecond durations.
+   */
+  readonly dateStrings?: boolean | undefined
+
+  /**
+   * Prepares statements and caches them per connection. Enabled by default.
+   * Disable it for proxies that cannot keep a statement between commands.
+   */
+  readonly prepare?: boolean | undefined
+
+  /** How many statements a connection keeps prepared. Defaults to `100`. */
+  readonly preparedStatementCacheSize?: number | undefined
+
+  /** Maximum joined message size in bytes. Defaults to 64 MiB. */
+  readonly maxMessageSize?: number | undefined
+}
+
+/**
+ * A result row, keyed by column name.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface Row {
+  readonly [column: string]: unknown
+}
+
+/**
+ * The outcome of one statement.
+ *
+ * **Details**
+ *
+ * A statement either returns a result set or returns counters, and which of
+ * the two it was is carried rather than left to be inferred from an empty
+ * column list. `affectedRows` and `lastInsertId` appear only where they mean
+ * something, so a `SELECT` cannot be asked for an insert id.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type Result = Data.TaggedEnum<{
+  /** A statement that returned a result set. */
+  readonly ResultSet: {
+    readonly rows: ReadonlyArray<Row>
+    readonly columns: ReadonlyArray<MysqlProtocol.Column>
+    readonly warnings: number
+    readonly info: string
+  }
+  /** A statement that returned counters instead of rows. */
+  readonly Ok: {
+    readonly affectedRows: number | bigint
+    readonly lastInsertId: number | bigint
+    readonly warnings: number
+    readonly info: string
+  }
+}>
+
+/**
+ * Constructors and refinements for `Result`, plus `rowsOf` for the common
+ * case of wanting a statement's rows and treating one that produced none as
+ * empty.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export const Result = {
+  // Spelled out rather than assigned onto `Data.taggedEnum`'s result: that is
+  // a proxy which manufactures a constructor for any property read from it,
+  // so an added helper is shadowed by a constructor of the same name.
+  ...(({ $is, $match, Ok, ResultSet }) => ({ $is, $match, Ok, ResultSet }))(Data.taggedEnum<Result>()),
+  /** A statement's rows, or none when it returned counters instead. */
+  rowsOf: (self: Result): ReadonlyArray<Row> => self._tag === "ResultSet" ? self.rows : []
+} as const
+
+/**
+ * A MySQL session.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export interface MysqlConnection {
+  readonly [TypeId]: TypeId
+  readonly config: Config
+  /** The server's id for this session, which `KILL` takes. */
+  readonly connectionId: number
+  readonly serverVersion: string
+  /** The capability flags both sides agreed on. */
+  readonly capabilities: number
+
+  /**
+   * Runs a text statement and returns one entry per result the server sent.
+   * A multi-statement request produces one entry per statement, in order.
+   */
+  readonly query: (sql: string) => Effect.Effect<ReadonlyArray<Result>, SqlError>
+
+  /** Runs a text statement and returns each result's rows as arrays. */
+  readonly queryValues: (sql: string) => Effect.Effect<ReadonlyArray<ReadonlyArray<unknown>>, SqlError>
+
+  /**
+   * Prepares a statement, binds its parameters and runs it over the binary
+   * protocol. The statement is cached, so preparing it costs an extra round
+   * trip only the first time.
+   *
+   * **Gotchas**
+   *
+   * A prepared statement carries exactly one statement, so a multi-statement
+   * request has to go through `query`.
+   */
+  readonly execute: (
+    sql: string,
+    params: ReadonlyArray<unknown>
+  ) => Effect.Effect<ReadonlyArray<Result>, SqlError>
+
+  /** Runs a prepared statement and returns its rows as arrays. */
+  readonly executeValues: (
+    sql: string,
+    params: ReadonlyArray<unknown>
+  ) => Effect.Effect<ReadonlyArray<ReadonlyArray<unknown>>, SqlError>
+
+  /**
+   * Runs a statement and emits its rows as they arrive, pausing the socket
+   * when the consumer falls behind.
+   *
+   * **Gotchas**
+   *
+   * The session is held for as long as the stream is open. Abandoning a stream
+   * before its last row cancels the statement with `KILL QUERY` and drains the
+   * rest of the reply, because a half-read result would desync the next
+   * command.
+   */
+  readonly stream: (
+    sql: string,
+    params: ReadonlyArray<unknown>
+  ) => Stream.Stream<Row, SqlError>
+
+  readonly ping: Effect.Effect<void, SqlError>
+}
+
+/**
+ * The service tag for `MysqlConnection`.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const MysqlConnection = Context.Service<MysqlConnection>("@effect/sql-mysql/MysqlConnection")
+
+/**
+ * Opens a MySQL session, closing it when the scope closes.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const make = (options: Config): Effect.Effect<MysqlConnection, SqlError, Scope.Scope> =>
+  Effect.flatMap(resolveConfig(options), (config) =>
+    Effect.acquireRelease(
+      connect(config).pipe(
+        Effect.timeoutOrElse({
+          duration: config.connectTimeout,
+          orElse: () =>
+            Effect.fail(
+              new SqlError({
+                reason: new ConnectionError({
+                  cause: new Error("Connection timed out"),
+                  message: "MysqlConnection: Connection timed out",
+                  operation: "connect"
+                })
+              })
+            )
+        }),
+        Effect.flatMap((session) => {
+          const connection = new MysqlConnectionImpl(options, config, session)
+          return Effect.as(connection.initialize(config), connection)
+        })
+      ),
+      (connection) => Effect.sync(() => connection.closeUnsafe()),
+      { interruptible: true }
+    ))
+
+// -----------------------------------------------------------------------------
+// session
+// -----------------------------------------------------------------------------
+
+interface Session {
+  socket: Duplex
+  readonly parser: MysqlProtocol.Parser
+  readonly handshake: MysqlProtocol.Handshake
+  readonly capabilities: number
+}
+
+/**
+ * Receives the packets of the command currently on the wire. A command
+ * installs one for as long as it runs.
+ */
+interface Consumer {
+  readonly onPacket: (packet: MysqlProtocol.Packet) => void
+  readonly onFatal: (error: SqlError) => void
+}
+
+/**
+ * What a session is doing.
+ *
+ * Being dead and having a command in flight are not combinable, and neither
+ * is being idle and holding a consumer, so the two are one value rather than
+ * two fields that could disagree.
+ */
+type SessionState = Data.TaggedEnum<{
+  readonly Idle: {}
+  readonly Busy: { readonly consumer: Consumer }
+  readonly Dead: { readonly error: SqlError }
+}>
+
+const SessionState = Data.taggedEnum<SessionState>()
+
+const idle = SessionState.Idle()
+
+/** How long a cancelled command has to drain before the session is written off. */
+const drainTimeoutMillis = 5000
+
+/** How many statements a connection keeps prepared unless told otherwise. */
+const defaultPreparedStatements = 100
+
+/** A statement the server has prepared on this connection. */
+
+/**
+ * Keeps prepared statements per connection, evicting the least recently used.
+ *
+ * Statement handles belong to the connection that made them, and the cache key
+ * is the SQL alone: unlike a PostgreSQL `Parse`, a MySQL prepare does not fix
+ * the parameter types, which are sent with each execution instead.
+ *
+ * `COM_STMT_CLOSE` has no reply, so an eviction costs no round trip: its frame
+ * rides along with the next request.
+ */
+class PreparedCache {
+  private readonly entries = new Map<string, Prepared>()
+  private closes: Array<Uint8Array> = []
+  readonly capacity: number
+
+  constructor(capacity: number) {
+    this.capacity = capacity
+  }
+
+  get(sql: string): Prepared | undefined {
+    const entry = this.entries.get(sql)
+    if (entry === undefined) return undefined
+    // Re-inserting moves the entry to the end, which is what makes the map's
+    // insertion order an LRU order.
+    this.entries.delete(sql)
+    this.entries.set(sql, entry)
+    return entry
+  }
+
+  set(sql: string, prepared: Prepared): void {
+    this.entries.set(sql, prepared)
+    while (this.entries.size > this.capacity) {
+      const oldest = this.entries.keys().next()
+      if (oldest.done === true) break
+      const evicted = this.entries.get(oldest.value)!
+      this.entries.delete(oldest.value)
+      this.closes.push(MysqlProtocol.encodeStmtClose(evicted.statementId))
+    }
+  }
+
+  takeCloses(): Array<Uint8Array> {
+    if (this.closes.length === 0) return []
+    const taken = this.closes
+    this.closes = []
+    return taken
+  }
+}
+
+/** Joins request frames into the single write that carries them. */
+const concat = (parts: ReadonlyArray<Uint8Array>): Uint8Array => {
+  if (parts.length === 1) return parts[0]
+  let total = 0
+  for (const part of parts) total += part.length
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const part of parts) {
+    out.set(part, offset)
+    offset += part.length
+  }
+  return out
+}
+
+class MysqlConnectionImpl implements MysqlConnection {
+  readonly [TypeId]: TypeId = TypeId
+  readonly config: Config
+  readonly resolved: ResolvedConfig
+  readonly session: Session
+  readonly connectionId: number
+  readonly serverVersion: string
+  readonly capabilities: number
+
+  /** Serializes commands: MySQL answers one request at a time. */
+  readonly wire = Semaphore.makeUnsafe(1)
+
+  readonly prepared: PreparedCache | undefined
+
+  state: SessionState = idle
+  closed = false
+  readonly fatalHooks = new Set<() => void>()
+
+  readonly [internalsKey]: ConnectionInternals
+
+  constructor(config: Config, resolved: ResolvedConfig, session: Session) {
+    this.config = config
+    this.resolved = resolved
+    this.session = session
+    this.connectionId = session.handshake.connectionId
+    this.serverVersion = session.handshake.serverVersion
+    this.capabilities = session.capabilities
+    this.prepared = resolved.prepare ? new PreparedCache(resolved.preparedStatementCacheSize) : undefined
+    this[internalsKey] = {
+      isDead: () => SessionState.$is("Dead")(this.state),
+      fatalHooks: this.fatalHooks
+    }
+    session.socket.on("data", this.onData)
+    session.socket.on("error", this.onSocketError)
+    session.socket.on("close", this.onSocketClose)
+  }
+
+  /** Applies the session settings that make decoding deterministic. */
+  initialize(config: ResolvedConfig): Effect.Effect<void, SqlError> {
+    return Effect.asVoid(this.query(`SET time_zone = '${config.timezone.replaceAll("'", "''")}'`))
+  }
+
+  private readonly onData = (chunk: Uint8Array): void => {
+    try {
+      this.session.parser.pushEach(chunk, this.dispatch)
+    } catch (cause) {
+      this.fatal(connectionError(cause, "MysqlConnection: Failed to parse server response", "execute"))
+    }
+  }
+
+  private readonly dispatch = (packet: MysqlProtocol.Packet): void => {
+    const state = this.state
+    if (!SessionState.$is("Busy")(state)) {
+      this.fatal(connectionError(
+        new Error("Received a packet with no command in flight"),
+        "MysqlConnection: Protocol desync",
+        "execute"
+      ))
+      return
+    }
+    state.consumer.onPacket(packet)
+  }
+
+  private readonly onSocketError = (cause: Error): void => {
+    this.fatal(connectionError(cause, "MysqlConnection: Connection failed", "execute"))
+  }
+
+  private readonly onSocketClose = (): void => {
+    this.fatal(connectionError(
+      new Error("Connection closed unexpectedly"),
+      "MysqlConnection: Connection closed",
+      "execute"
+    ))
+  }
+
+  /** Kills the session and fails whatever was on the wire. */
+  fatal(error: SqlError, destroySocket = true): void {
+    if (SessionState.$is("Dead")(this.state)) return
+    const previous = this.state
+    this.state = SessionState.Dead({ error })
+    if (destroySocket) this.session.socket.destroy()
+    if (SessionState.$is("Busy")(previous)) previous.consumer.onFatal(error)
+    if (this.closed) return
+    for (const hook of this.fatalHooks) hook()
+    this.fatalHooks.clear()
+  }
+
+  closeUnsafe(): void {
+    if (this.closed) return
+    this.closed = true
+    const socket = this.session.socket
+    socket.off("data", this.onData)
+    socket.off("error", this.onSocketError)
+    socket.off("close", this.onSocketClose)
+    socket.on("error", ignoreError)
+    try {
+      socket.end(MysqlProtocol.encodeQuit())
+    } catch {
+      socket.destroy()
+    }
+  }
+
+  /**
+   * Writes a request and feeds every packet of its reply to `machine`, which
+   * settles the effect when the command completes.
+   */
+  query(sql: string): Effect.Effect<ReadonlyArray<Result>, SqlError> {
+    return runCommand(
+      this,
+      MysqlProtocol.encodeQuery(sql),
+      "execute",
+      (reader) => readResults(reader, textRows(this.resolved.decode))
+    )
+  }
+
+  queryValues(sql: string): Effect.Effect<ReadonlyArray<ReadonlyArray<unknown>>, SqlError> {
+    return runCommand(
+      this,
+      MysqlProtocol.encodeQuery(sql),
+      "execute",
+      (reader) => readValues(reader, textRows(this.resolved.decode))
+    )
+  }
+
+  /**
+   * Returns the server's handle for `sql`, preparing it when the cache misses.
+   */
+  private prepareStatement(sql: string): Effect.Effect<Prepared, SqlError> {
+    return Effect.suspend(() => {
+      const cache = this.prepared
+      const cached = cache?.get(sql)
+      if (cached !== undefined) return Effect.succeed(cached)
+      const closes = cache?.takeCloses() ?? []
+      const request = concat([...closes, MysqlProtocol.encodeStmtPrepare(sql)])
+      return Effect.tap(
+        runCommand(this, request, "prepare", (reader) => readPrepared(reader.one)),
+        (prepared) => Effect.sync(() => cache?.set(sql, prepared))
+      )
+    })
+  }
+
+  /**
+   * Builds the request that runs a statement, preparing it when preparation is
+   * enabled and writing the parameters into the SQL when it is not.
+   */
+  private request(
+    sql: string,
+    params: ReadonlyArray<unknown>,
+    operation: string
+  ): Effect.Effect<{ readonly bytes: Uint8Array; readonly rows: RowDecoder }, SqlError> {
+    if (!this.resolved.prepare) {
+      return Effect.map(
+        Effect.try({
+          try: () => bindText(sql, params),
+          catch: (cause) => queryError(cause, "MysqlConnection: Failed to bind statement parameters", operation)
+        }),
+        (text) => ({ bytes: MysqlProtocol.encodeQuery(text), rows: textRows(this.resolved.decode) })
+      )
+    }
+    return Effect.flatMap(this.prepareStatement(sql), (prepared) => {
+      if (prepared.parameterCount !== params.length) {
+        return Effect.fail(queryError(
+          new Error(`Statement takes ${prepared.parameterCount} parameter(s) but ${params.length} were supplied`),
+          "MysqlConnection: Wrong number of parameters",
+          operation
+        ))
+      }
+      const bound = MysqlTypes.bindParameters(params)
+      if (EffectResult.isFailure(bound)) {
+        return Effect.fail(queryError(
+          bound.failure,
+          "MysqlConnection: Failed to bind statement parameters",
+          operation
+        ))
+      }
+      // Preparing this statement may have evicted another. Its close frame
+      // rides along here rather than waiting for the next prepare, which may
+      // never come.
+      return Effect.succeed({
+        bytes: concat([
+          ...(this.prepared?.takeCloses() ?? []),
+          MysqlProtocol.encodeStmtExecute({
+            statementId: prepared.statementId,
+            parameters: bound.success
+          })
+        ]),
+        rows: binaryRows(this.resolved.decode)
+      })
+    })
+  }
+
+  private runPrepared(sql: string, params: ReadonlyArray<unknown>): Effect.Effect<ReadonlyArray<Result>, SqlError> {
+    return Effect.flatMap(
+      this.request(sql, params, "execute"),
+      (plan) => runCommand(this, plan.bytes, "execute", (reader) => readResults(reader, plan.rows))
+    )
+  }
+
+  private runPreparedValues(
+    sql: string,
+    params: ReadonlyArray<unknown>
+  ): Effect.Effect<ReadonlyArray<ReadonlyArray<unknown>>, SqlError> {
+    return Effect.flatMap(
+      this.request(sql, params, "execute"),
+      (plan) => runCommand(this, plan.bytes, "execute", (reader) => readValues(reader, plan.rows))
+    )
+  }
+
+  /** Cancels the statement on the wire, on a connection of its own. */
+  get killQuery(): Effect.Effect<void> {
+    return Effect.scoped(
+      Effect.flatMap(make(this.config), (side) => side.query(`KILL QUERY ${this.connectionId}`))
+    ).pipe(
+      Effect.timeoutOrElse({ duration: Duration.millis(drainTimeoutMillis), orElse: () => Effect.void }),
+      Effect.ignore
+    )
+  }
+
+  stream(sql: string, params: ReadonlyArray<unknown>): Stream.Stream<Row, SqlError> {
+    return Stream.unwrap(Effect.map(
+      this.request(sql, params, "stream"),
+      (plan) => streamOf(this, plan.bytes, plan.rows)
+    ))
+  }
+
+  execute(sql: string, params: ReadonlyArray<unknown>): Effect.Effect<ReadonlyArray<Result>, SqlError> {
+    return this.runPrepared(sql, params)
+  }
+
+  executeValues(
+    sql: string,
+    params: ReadonlyArray<unknown>
+  ): Effect.Effect<ReadonlyArray<ReadonlyArray<unknown>>, SqlError> {
+    return this.runPreparedValues(sql, params)
+  }
+
+  get ping(): Effect.Effect<void, SqlError> {
+    return runCommand(
+      this,
+      MysqlProtocol.encodePing(),
+      "ping",
+      (reader) => readAcknowledgement(reader.one, "MysqlConnection: Ping failed", "ping")
+    )
+  }
+}
+
+const ignoreError = (_: Error) => {}
+
+// -----------------------------------------------------------------------------
+// text query machine
+// -----------------------------------------------------------------------------
+
+/**
+ * Builds the row decoder for a result set, once its columns are known.
+ */
+
+const rowsOfCompleted = <A>(completed: Completed<A>): ReadonlyArray<A> =>
+  Completed.$match(completed, {
+    ResultSet: ({ rows }) => rows,
+    Ok: () => []
+  })
+
+const asResult = <A>(completed: Completed<A>): Result =>
+  Completed.$match(completed, {
+    ResultSet: ({ columns, ok, rows }) =>
+      Result.ResultSet({
+        rows: rows as ReadonlyArray<Row>,
+        columns,
+        warnings: ok.warnings,
+        info: ok.info
+      }),
+    Ok: ({ ok }) =>
+      Result.Ok({
+        affectedRows: ok.affectedRows,
+        lastInsertId: ok.lastInsertId,
+        warnings: ok.warnings,
+        info: ok.info
+      })
+  })
+
+/**
+ * Reads the reply to `COM_STMT_PREPARE`.
+ *
+ * One column definition per parameter follows, then one per result column,
+ * with no EOF packet between the groups because `CLIENT_DEPRECATE_EOF` is
+ * negotiated. None is kept: the execution's own reply describes its columns
+ * again.
+ */
+
+/** Reads a reply as rows keyed by column name. */
+const readResults = (reader: PacketReader, rowDecoder: RowDecoder): Effect.Effect<ReadonlyArray<Result>, SqlError> =>
+  Effect.map(readReply(reader, rowDecoder, toRow), (statements) => statements.map(asResult))
+
+/** Reads a reply as bare value arrays, reporting the last statement's rows. */
+const readValues = (
+  reader: PacketReader,
+  rowDecoder: RowDecoder
+): Effect.Effect<ReadonlyArray<ReadonlyArray<unknown>>, SqlError> =>
+  Effect.map(
+    readReply(reader, rowDecoder, (_, values) => values),
+    (statements) => statements.length === 0 ? [] : rowsOfCompleted(statements[statements.length - 1])
+  )
+
+/** Reads the reply to a command that answers with a single OK packet. */
+
+/**
+ * Writes a request on a connection and hands its reply to `read`, one packet
+ * at a time.
+ *
+ * The wire is held for the whole exchange, because MySQL numbers the packets
+ * of a command and answers one at a time. The connection is passed in rather
+ * than captured, so the generator needs no binding of its own.
+ */
+const runCommand = <A>(
+  connection: MysqlConnectionImpl,
+  request: Uint8Array,
+  operation: string,
+  read: (reader: PacketReader) => Effect.Effect<A, SqlError>
+): Effect.Effect<A, SqlError> =>
+  connection.wire.withPermit(Effect.gen(function*() {
+    if (SessionState.$is("Dead")(connection.state)) return yield* Effect.fail(connection.state.error)
+    const queue = yield* Queue.make<MysqlProtocol.Packet, SqlError>()
+    connection.state = SessionState.Busy({
+      consumer: {
+        onPacket: (packet) => {
+          Queue.offerUnsafe(queue, packet)
+        },
+        onFatal: (error) => {
+          Queue.failCauseUnsafe(queue, Cause.fail(error))
+        }
+      }
+    })
+    // The server restarts the count at zero for each command, so its first
+    // reply packet carries the id after our request's.
+    connection.session.parser.expectedSequenceId = 1
+    connection.session.socket.write(request)
+    return yield* read(makeReader(queue)).pipe(
+      // A reader that fails has still read the reply to its end. One that is
+      // interrupted has not, and a half-read reply would desync the next
+      // command, which MySQL offers no way to abandon in place. Writing the
+      // session off is the honest outcome; the pool replaces it.
+      Effect.onInterrupt(() =>
+        Effect.sync(() =>
+          connection.fatal(connectionError(
+            new Error("Command interrupted"),
+            "MysqlConnection: Command interrupted",
+            operation
+          ))
+        )
+      ),
+      Effect.onExit(() =>
+        Effect.sync(() => {
+          if (SessionState.$is("Busy")(connection.state)) connection.state = idle
+        })
+      )
+    )
+  }))
+
+/** Reads the column definitions that open a result set. */
+
+/** Builds a row object from a column-ordered list of values. */
+const toRow = (columns: ReadonlyArray<MysqlProtocol.Column>, values: ReadonlyArray<unknown>): Row => {
+  const row: Record<string, unknown> = {}
+  for (let index = 0; index < columns.length; index++) row[columns[index].name] = values[index]
+  return row
+}
+
+/** Reads a streamed result set's rows, handing each one to `push`. */
+
+/**
+ * Streams a result set off a connection.
+ *
+ * The connection is passed in rather than captured, so the generator needs no
+ * binding of its own.
+ */
+const streamOf = (
+  connection: MysqlConnectionImpl,
+  request: Uint8Array,
+  rowDecoder: RowDecoder
+): Stream.Stream<Row, SqlError> =>
+  SqlStream.asyncPauseResume<Row, SqlError>((emit) =>
+    Effect.gen(function*() {
+      let done = false
+
+      yield* Effect.acquireRelease(
+        // The session answers one command at a time, so the stream holds the
+        // wire until its result set ends.
+        connection.wire.take(1),
+        () =>
+          Effect.suspend(() => {
+            // Backpressure pauses the socket when the stream's queue fills and
+            // resumes it only once that queue drains. A consumer that walks
+            // away mid-result-set never drains it, so the socket can be left
+            // paused with the rest of the reply still on the wire. Nothing
+            // below can read a paused socket, so lift it first — the stream is
+            // gone and the wire is ours. Resuming a flowing socket is a no-op.
+            connection.session.socket.resume()
+
+            if (done || SessionState.$is("Dead")(connection.state)) {
+              if (SessionState.$is("Busy")(connection.state)) connection.state = idle
+              return connection.wire.release(1)
+            }
+            // Abandoned before the last row. The reader has already been
+            // interrupted, so nothing is consuming the rest of the reply:
+            // stop the server sending and read to the terminator here, or the
+            // next command starts mid-result-set.
+            return connection.killQuery.pipe(
+              Effect.andThen(Effect.ignore(drainReply(reader.one))),
+              Effect.timeoutOrElse({
+                duration: Duration.millis(drainTimeoutMillis),
+                orElse: () =>
+                  Effect.sync(() =>
+                    connection.fatal(connectionError(
+                      new Error("Timed out draining a cancelled stream"),
+                      "MysqlConnection: Failed to cancel a stream",
+                      "stream"
+                    ))
+                  )
+              }),
+              Effect.andThen(Effect.sync(() => {
+                if (SessionState.$is("Busy")(connection.state)) connection.state = idle
+              })),
+              Effect.andThen(connection.wire.release(1))
+            )
+          })
+      )
+
+      if (SessionState.$is("Dead")(connection.state)) return yield* Effect.fail(connection.state.error)
+
+      const queue = yield* Queue.make<MysqlProtocol.Packet, SqlError>()
+      // One reader for the stream and for the drain that may follow it, so the
+      // drain continues from where the reader stopped.
+      const reader = makeReader(queue)
+      connection.state = SessionState.Busy({
+        consumer: {
+          onPacket: (packet) => {
+            Queue.offerUnsafe(queue, packet)
+          },
+          onFatal: (error) => {
+            Queue.failCauseUnsafe(queue, Cause.fail(error))
+          }
+        }
+      })
+      connection.session.parser.expectedSequenceId = 1
+      connection.session.socket.write(request)
+
+      // Scoped, so closing the stream interrupts this before the finalizer
+      // below runs. Only a reader that reached the terminator has read the
+      // reply to its end; one that was interrupted leaves the rest in flight.
+      yield* Effect.forkScoped(
+        Effect.matchEffect(readStream(reader, rowDecoder, toRow, emit), {
+          onFailure: (error) =>
+            Effect.sync(() => {
+              done = true
+              emit.fail(error)
+            }),
+          onSuccess: () =>
+            Effect.sync(() => {
+              done = true
+              emit.end()
+            })
+        })
+      )
+
+      return {
+        onPause: () => {
+          connection.session.socket.pause()
+        },
+        onResume: () => {
+          connection.session.socket.resume()
+        }
+      }
+    })
+  )
+
+// -----------------------------------------------------------------------------
+// connecting
+// -----------------------------------------------------------------------------
+
+/** Capabilities this client cannot work without. Every one is MySQL 8 standard. */
+const requiredCapabilities: ReadonlyArray<readonly [name: string, flag: MysqlProtocol.Capability]> = [
+  ["CLIENT_PROTOCOL_41", MysqlProtocol.Capability.protocol41],
+  ["CLIENT_PLUGIN_AUTH", MysqlProtocol.Capability.pluginAuth],
+  ["CLIENT_SECURE_CONNECTION", MysqlProtocol.Capability.secureConnection],
+  ["CLIENT_DEPRECATE_EOF", MysqlProtocol.Capability.deprecateEof],
+  ["CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA", MysqlProtocol.Capability.pluginAuthLenencClientData]
+]
+
+/** Capabilities taken when offered. */
+const optionalCapabilities: ReadonlyArray<MysqlProtocol.Capability> = [
+  MysqlProtocol.Capability.longPassword,
+  MysqlProtocol.Capability.longFlag,
+  MysqlProtocol.Capability.transactions,
+  MysqlProtocol.Capability.multiStatements,
+  MysqlProtocol.Capability.multiResults,
+  MysqlProtocol.Capability.psMultiResults
+]
+
+/**
+ * The packets arriving on a socket, and the handlers that put them there.
+ *
+ * A TLS upgrade replaces the socket underneath, so attaching and detaching is
+ * separate from the stream itself: the parser and the packets already read
+ * carry across the swap.
+ */
+interface PacketSource {
+  readonly parser: MysqlProtocol.Parser
+  readonly take: Take
+  readonly attach: (socket: Duplex) => void
+  readonly detach: (socket: Duplex) => void
+}
+
+const makePacketSource = (maxMessageSize: number | undefined): Effect.Effect<PacketSource> =>
+  Effect.map(Queue.make<MysqlProtocol.Packet, SqlError>(), (queue) => {
+    const parser = MysqlProtocol.makeParser({ maxMessageSize })
+    const offer = (packet: MysqlProtocol.Packet): void => {
+      Queue.offerUnsafe(queue, packet)
+    }
+    const die = (error: SqlError): void => {
+      Queue.failCauseUnsafe(queue, Cause.fail(error))
+    }
+    const onData = (chunk: Uint8Array): void => {
+      try {
+        parser.pushEach(chunk, offer)
+      } catch (cause) {
+        die(connectionError(cause, "MysqlConnection: Failed to parse the server handshake", "connect"))
+      }
+    }
+    const onError = (cause: Error): void => die(connectionError(cause, "MysqlConnection: Failed to connect", "connect"))
+    const onClose = (): void =>
+      die(connectionError(
+        new Error("Connection closed unexpectedly"),
+        "MysqlConnection: Connection closed during startup",
+        "connect"
+      ))
+    return {
+      parser,
+      take: makeReader(queue).one,
+      attach: (socket) => {
+        socket.on("data", onData)
+        socket.on("error", onError)
+        socket.on("close", onClose)
+      },
+      detach: (socket) => {
+        socket.off("data", onData)
+        socket.off("error", onError)
+        socket.off("close", onClose)
+      }
+    }
+  })
+
+/** Opens the transport, waiting for it to be connected. */
+const openSocket = (config: ResolvedConfig): Effect.Effect<Duplex, SqlError> =>
+  Effect.callback<Duplex, SqlError>((resume) => {
+    let socket: Duplex
+    try {
+      socket = Transport.$match(config.transport, {
+        // A statement is one write and then a wait for its answer, so Nagle
+        // has nothing to coalesce and only holds the write back.
+        Tcp: ({ host, port }) => Net.connect({ host, port, noDelay: true }),
+        Unix: ({ path }) => Net.connect({ path }),
+        Supplied: ({ open }) => open()
+      })
+    } catch (cause) {
+      resume(Effect.fail(connectionError(cause, "MysqlConnection: Failed to connect", "connect")))
+      return
+    }
+    // A caller-supplied transport arrives ready, so there is no connect to wait for.
+    if (Transport.$is("Supplied")(config.transport)) {
+      resume(Effect.succeed(socket))
+      return
+    }
+    const settled = { done: false }
+    const clear = (): void => {
+      socket.off("connect", onConnect)
+      socket.off("error", onError)
+    }
+    function onConnect(): void {
+      if (settled.done) return
+      settled.done = true
+      clear()
+      resume(Effect.succeed(socket))
+    }
+    function onError(cause: Error): void {
+      if (settled.done) return
+      settled.done = true
+      clear()
+      socket.destroy()
+      resume(Effect.fail(connectionError(cause, "MysqlConnection: Failed to connect", "connect")))
+    }
+    socket.once("connect", onConnect)
+    socket.once("error", onError)
+    return Effect.sync(() => {
+      if (settled.done) return
+      settled.done = true
+      clear()
+      socket.destroy()
+    })
+  })
+
+/** Upgrades a connected socket to TLS in place. */
+const upgradeTls = (raw: Duplex, config: ResolvedConfig): Effect.Effect<Duplex, SqlError> =>
+  Effect.callback<Duplex, SqlError>((resume) => {
+    const secure = Tls.connect({
+      // Only a TCP transport has a name to present; a socket path or a
+      // caller's duplex has none, and a caller who needs one sets it through
+      // `ssl`, which is spread after this and so still wins.
+      ...(Transport.$is("Tcp")(config.transport) ? { host: config.transport.host } : {}),
+      ...(typeof config.ssl === "object" ? config.ssl : {}),
+      socket: raw as Net.Socket
+    })
+    const settled = { done: false }
+    const clear = (): void => {
+      secure.off("secureConnect", onSecure)
+      secure.off("error", onError)
+    }
+    function onSecure(): void {
+      if (settled.done) return
+      settled.done = true
+      clear()
+      resume(Effect.succeed(secure))
+    }
+    function onError(cause: Error): void {
+      if (settled.done) return
+      settled.done = true
+      clear()
+      resume(Effect.fail(connectionError(cause, "MysqlConnection: TLS negotiation failed", "connect")))
+    }
+    secure.once("secureConnect", onSecure)
+    secure.once("error", onError)
+    return Effect.sync(() => {
+      if (settled.done) return
+      settled.done = true
+      clear()
+      secure.destroy()
+    })
+  })
+
+/** Settles on the capabilities both sides can agree on, or refuses the server. */
+const negotiate = (
+  server: MysqlProtocol.Capabilities,
+  config: ResolvedConfig,
+  useTls: boolean
+): Effect.Effect<MysqlProtocol.Capabilities, SqlError> => {
+  for (const [name, flag] of requiredCapabilities) {
+    if (!MysqlProtocol.Capabilities.has(server, flag)) {
+      return Effect.fail(connectionError(
+        new Error(`The server does not offer ${name}`),
+        "MysqlConnection: Unsupported server, MySQL 8.0 or newer is required",
+        "connect"
+      ))
+    }
+  }
+  if (useTls && !MysqlProtocol.Capabilities.has(server, MysqlProtocol.Capability.ssl)) {
+    return Effect.fail(connectionError(
+      new Error("The server does not support TLS"),
+      "MysqlConnection: Server refused TLS",
+      "connect"
+    ))
+  }
+  return Effect.succeed(MysqlProtocol.Capabilities.of([
+    ...requiredCapabilities.map(([, flag]) => flag),
+    ...optionalCapabilities.filter((flag) => MysqlProtocol.Capabilities.has(server, flag)),
+    ...(config.database === undefined ? [] : [MysqlProtocol.Capability.connectWithDb]),
+    ...(useTls ? [MysqlProtocol.Capability.ssl] : [])
+  ]))
+}
+
+const authError = (cause: unknown, message: string): SqlError =>
+  new SqlError({ reason: new AuthenticationError({ cause, message, operation: "connect" }) })
+
+/** Computes the response a named plugin owes to a challenge. */
+const authResponse = (
+  plugin: string,
+  password: string,
+  scramble: Uint8Array,
+  usingTls: boolean
+): Effect.Effect<MysqlAuth.Reply, SqlError> => {
+  const computed = MysqlAuth.respond({ plugin, password, scramble, usingTls })
+  return EffectResult.isSuccess(computed)
+    ? Effect.succeed(computed.success)
+    : Effect.fail(authError(computed.failure, `MysqlConnection: ${computed.failure.message}`))
+}
+
+/**
+ * Where a reply leaves the exchange: asking for a key means the next packet is
+ * the key rather than a verdict.
+ */
+const stateAfter = (reply: MysqlAuth.Reply, plugin: string, scramble: Uint8Array): AuthState =>
+  MysqlAuth.Reply.$is("RequestPublicKey")(reply)
+    ? AuthState.AwaitingPublicKey({ scramble })
+    : AuthState.Exchanging({ plugin, scramble })
+
+/**
+ * Where an authentication exchange has got to.
+ *
+ * The plugin and its challenge change when the server switches plugins, and
+ * `caching_sha2_password` adds one step where the next packet is a public key
+ * rather than a verdict. Holding that as one value keeps the states apart;
+ * as separate fields any combination of them would be expressible.
+ */
+type AuthState = Data.TaggedEnum<{
+  readonly Exchanging: { readonly plugin: string; readonly scramble: Uint8Array }
+  readonly AwaitingPublicKey: { readonly scramble: Uint8Array }
+}>
+
+const AuthState = Data.taggedEnum<AuthState>()
+
+/**
+ * Runs the exchange that follows the handshake response, until the server
+ * accepts the client or refuses it.
+ */
+const authenticate = Effect.fnUntraced(function*(options: {
+  readonly source: PacketSource
+  readonly socket: () => Duplex
+  readonly password: string
+  readonly usingTls: boolean
+  readonly state: AuthState
+}): Effect.fn.Return<void, SqlError> {
+  /** Writes a reply to the packet just read and advances the count. */
+  const respond = (received: number, build: (sequenceId: number) => Uint8Array): void => {
+    const sequenceId = (received + 1) & 0xff
+    options.source.parser.expectedSequenceId = (sequenceId + 1) & 0xff
+    options.socket().write(build(sequenceId))
+  }
+
+  let state: AuthState = options.state
+
+  while (true) {
+    const packet = yield* options.source.take
+    const payload = packet.payload
+    const first = payload.length === 0 ? -1 : payload[0]
+
+    if (first === 0xff) {
+      const err = yield* take(
+        Effect.succeed(packet),
+        MysqlProtocol.decodeErr,
+        "MysqlConnection: Failed to read an error response",
+        "connect"
+      )
+      return yield* Effect.fail(
+        new SqlError({ reason: classifyErr(err, "MysqlConnection: Failed to connect", "connect") })
+      )
+    }
+
+    // An OK packet is the server accepting the client.
+    if (first === 0x00) return
+
+    if (first === 0xfe) {
+      const request = yield* take(
+        Effect.succeed(packet),
+        MysqlProtocol.decodeAuthSwitchRequest,
+        "MysqlConnection: Failed to read an AuthSwitchRequest",
+        "connect"
+      )
+      const reply = yield* authResponse(request.plugin, options.password, request.scramble, options.usingTls)
+      state = stateAfter(reply, request.plugin, request.scramble)
+      respond(packet.sequenceId, (sequenceId) => MysqlProtocol.encodeAuthData(reply.bytes, sequenceId))
+      continue
+    }
+
+    if (first !== 0x01) {
+      return yield* Effect.fail(connectionError(
+        new Error(`Unexpected packet 0x${first.toString(16)} during authentication`),
+        "MysqlConnection: Protocol desync",
+        "connect"
+      ))
+    }
+
+    const data = yield* take(
+      Effect.succeed(packet),
+      MysqlProtocol.decodeAuthMoreData,
+      "MysqlConnection: Failed to read an AuthMoreData packet",
+      "connect"
+    )
+
+    if (AuthState.$is("AwaitingPublicKey")(state)) {
+      const encrypted = MysqlAuth.encryptedPassword({
+        password: options.password,
+        scramble: state.scramble,
+        publicKey: Buffer.from(data).toString("utf8")
+      })
+      if (EffectResult.isFailure(encrypted)) {
+        return yield* Effect.fail(
+          authError(encrypted.failure, "MysqlConnection: Failed to encrypt the password")
+        )
+      }
+      state = AuthState.Exchanging({ plugin: MysqlProtocol.AuthPlugin.cachingSha2Password, scramble: state.scramble })
+      respond(packet.sequenceId, (sequenceId) => MysqlProtocol.encodeAuthData(encrypted.success, sequenceId))
+      continue
+    }
+
+    if (state.plugin !== MysqlProtocol.AuthPlugin.cachingSha2Password) {
+      return yield* Effect.fail(authError(
+        new Error(`Plugin ${state.plugin} sent unexpected data`),
+        "MysqlConnection: Authentication failed"
+      ))
+    }
+
+    const status = data[0]
+    // The password matched the server's cache; the OK packet follows.
+    if (status === MysqlAuth.CachingSha2.fastAuthSuccess) continue
+    if (status !== MysqlAuth.CachingSha2.fullAuthRequired) {
+      return yield* Effect.fail(authError(
+        new Error(`Unexpected caching_sha2_password status 0x${(status ?? 0).toString(16)}`),
+        "MysqlConnection: Authentication failed"
+      ))
+    }
+    if (options.usingTls) {
+      // The server has to see the password to fill its cache. Over TLS the
+      // socket already protects it.
+      respond(
+        packet.sequenceId,
+        (sequenceId) => MysqlProtocol.encodeAuthData(MysqlAuth.cleartextPassword(options.password), sequenceId)
+      )
+      continue
+    }
+    state = AuthState.AwaitingPublicKey({ scramble: state.scramble })
+    respond(
+      packet.sequenceId,
+      (sequenceId) => MysqlProtocol.encodeAuthData(new Uint8Array([MysqlAuth.CachingSha2.requestPublicKey]), sequenceId)
+    )
+  }
+})
+
+/**
+ * Opens a session: connect, read the server's greeting, agree on capabilities,
+ * upgrade to TLS if asked, and authenticate.
+ */
+const connect = Effect.fnUntraced(function*(config: ResolvedConfig): Effect.fn.Return<Session, SqlError> {
+  const useTls = config.ssl !== false
+  const source = yield* makePacketSource(config.maxMessageSize)
+  // The TLS upgrade replaces the socket, so it lives in a cell the rest of
+  // the handshake reads through rather than in a binding.
+  const transport = { socket: yield* openSocket(config) }
+  source.attach(transport.socket)
+
+  return yield* Effect.gen(function*() {
+    // The reply's sequence id comes from the packet, not from the greeting
+    // it carries, so the two are read separately.
+    const greetingPacket = yield* source.take
+    // A server that will not take the connection at all says so instead of
+    // greeting: too many connections, or a host blocked after repeated
+    // failures. Reading that as a malformed handshake would bury the one
+    // thing the caller can act on, so it is decoded as the error it is.
+    if (MysqlProtocol.isErr(greetingPacket.payload)) {
+      const err = yield* decodedAs(
+        MysqlProtocol.decodeErr(greetingPacket.payload),
+        "MysqlConnection: Failed to read the server error",
+        "connect"
+      )
+      return yield* Effect.fail(
+        new SqlError({ reason: classifyErr(err, "MysqlConnection: Failed to connect", "connect") })
+      )
+    }
+    const greeting = yield* decodedAs(
+      MysqlProtocol.decodeHandshake(greetingPacket.payload),
+      "MysqlConnection: Failed to read the server handshake",
+      "connect"
+    )
+    const capabilities = yield* negotiate(greeting.capabilities, config, useTls)
+    const plugin = greeting.authPlugin === ""
+      ? MysqlProtocol.AuthPlugin.cachingSha2Password
+      : greeting.authPlugin
+    const password = config.password ?? ""
+    const reply = yield* authResponse(plugin, password, greeting.scramble, useTls)
+
+    const writeHandshakeResponse = (sequenceId: number): void => {
+      source.parser.expectedSequenceId = (sequenceId + 1) & 0xff
+      transport.socket.write(MysqlProtocol.encodeHandshakeResponse({
+        capabilities,
+        collation: MysqlProtocol.defaultCollation,
+        username: config.username,
+        authResponse: reply.bytes,
+        database: config.database,
+        authPlugin: plugin,
+        sequenceId
+      }))
+    }
+
+    if (useTls) {
+      // TLS is negotiated in place: the 32-byte header goes out in the clear,
+      // the socket is upgraded, and the full response follows encrypted.
+      const sslSequenceId = (greetingPacket.sequenceId + 1) & 0xff
+      transport.socket.write(MysqlProtocol.encodeSslRequest({
+        capabilities,
+        collation: MysqlProtocol.defaultCollation,
+        sequenceId: sslSequenceId
+      }))
+      const raw = transport.socket
+      source.detach(raw)
+      transport.socket = yield* upgradeTls(raw, config)
+      source.attach(transport.socket)
+      writeHandshakeResponse((sslSequenceId + 1) & 0xff)
+    } else {
+      writeHandshakeResponse((greetingPacket.sequenceId + 1) & 0xff)
+    }
+
+    yield* authenticate({
+      source,
+      socket: () => transport.socket,
+      password,
+      usingTls: useTls,
+      state: stateAfter(reply, plugin, greeting.scramble)
+    })
+
+    // The session's own handlers replace these once it is running.
+    source.detach(transport.socket)
+    return { socket: transport.socket, parser: source.parser, handshake: greeting, capabilities }
+  }).pipe(
+    Effect.onError(() =>
+      Effect.sync(() => {
+        source.detach(transport.socket)
+        transport.socket.destroy()
+      })
+    )
+  )
+})
+
+// -----------------------------------------------------------------------------
+// configuration
+// -----------------------------------------------------------------------------
+
+/**
+ * How a session reaches the server.
+ *
+ * The three ways are mutually exclusive, so they are one value rather than a
+ * host, a port, a socket path and a stream factory that could all be set at
+ * once. Resolution decides which applies, and `openSocket` reads the decision
+ * instead of re-deriving it from a precedence of `undefined` checks.
+ */
+type Transport = Data.TaggedEnum<{
+  readonly Tcp: { readonly host: string; readonly port: number }
+  readonly Unix: { readonly path: string }
+  /** A duplex the caller supplies, already routed and already connected. */
+  readonly Supplied: { readonly open: () => Duplex }
+}>
+const Transport = Data.taggedEnum<Transport>()
+
+interface ResolvedConfig {
+  readonly transport: Transport
+  readonly ssl: boolean | ConnectionOptions
+  readonly database: string | undefined
+  readonly username: string
+  readonly password: string | undefined
+  readonly connectTimeout: Duration.Duration
+  readonly timezone: string
+  readonly decode: MysqlTypes.DecodeOptions
+  readonly prepare: boolean
+  readonly preparedStatementCacheSize: number
+  readonly maxMessageSize: number | undefined
+}
+
+const resolveConfig = (options: Config): Effect.Effect<ResolvedConfig, SqlError> =>
+  Effect.suspend(() => {
+    const parsed: EffectResult.Result<UrlConfig, SqlError> = options.url !== undefined
+      ? parseUrl(Redacted.value(options.url))
+      : EffectResult.succeed({})
+    if (EffectResult.isFailure(parsed)) return Effect.fail(parsed.failure)
+    const url = parsed.success
+    const host = options.host ?? url.host ?? "localhost"
+    const port = options.port ?? url.port ?? 3306
+    const username = options.username ?? url.username ?? process.env.USER ?? process.env.USERNAME
+    if (username === undefined) {
+      return Effect.fail(configError("No username configured"))
+    }
+    // A leading slash in `host` is how MySQL clients have always spelled a
+    // socket path, so it is honoured here and then never looked at again.
+    const path = options.path ?? (host.startsWith("/") ? host : undefined)
+    return Effect.succeed<ResolvedConfig>({
+      transport: options.stream !== undefined
+        ? Transport.Supplied({ open: options.stream })
+        : path !== undefined
+        ? Transport.Unix({ path })
+        : Transport.Tcp({ host, port }),
+      ssl: options.ssl ?? url.ssl ?? false,
+      database: options.database ?? url.database,
+      username,
+      password: options.password !== undefined ? Redacted.value(options.password) : url.password,
+      connectTimeout: Duration.fromInputUnsafe(options.connectTimeout ?? Duration.seconds(5)),
+      timezone: options.timezone ?? "+00:00",
+      decode: { bigintAsNumber: options.bigintAsNumber, dateStrings: options.dateStrings },
+      prepare: options.prepare ?? true,
+      preparedStatementCacheSize: options.preparedStatementCacheSize ?? defaultPreparedStatements,
+      maxMessageSize: options.maxMessageSize
+    })
+  })

--- a/packages/sql/mysql/src/MysqlMigrator.ts
+++ b/packages/sql/mysql/src/MysqlMigrator.ts
@@ -1,0 +1,117 @@
+/**
+ * Runs database migrations for MySQL projects that use Effect SQL.
+ *
+ * This module reuses the shared SQL migrator and connects it to MySQL. It
+ * exposes the common migration helpers and adds `run` and `layer` functions
+ * that apply pending migration files with the current SQL client. When schema
+ * dumps are requested, it uses `mysqldump` and the usual process and filesystem
+ * services.
+ *
+ * @since 4.0.0
+ */
+import * as Effect from "effect/Effect"
+import * as FileSystem from "effect/FileSystem"
+import * as Layer from "effect/Layer"
+import * as Path from "effect/Path"
+import * as ChildProcess from "effect/unstable/process/ChildProcess"
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner"
+import * as Migrator from "effect/unstable/sql/Migrator"
+import type { SqlClient } from "effect/unstable/sql/SqlClient"
+import type { SqlError } from "effect/unstable/sql/SqlError"
+import { resolveAddress } from "./internal/config.ts"
+import { MysqlClient } from "./MysqlClient.ts"
+
+/**
+ * @since 4.0.0
+ */
+export * from "effect/unstable/sql/Migrator"
+
+/**
+ * Runs MySQL migrations using the configured clients. Schema dumps use `mysqldump` and require child process, filesystem, and path services.
+ *
+ * @category running
+ * @since 4.0.0
+ */
+export const run: <R2 = never>(
+  options: Migrator.MigratorOptions<R2>
+) => Effect.Effect<
+  ReadonlyArray<readonly [id: number, name: string]>,
+  Migrator.MigrationError | SqlError,
+  | SqlClient
+  | MysqlClient
+  | ChildProcessSpawner.ChildProcessSpawner
+  | FileSystem.FileSystem
+  | Path.Path
+  | R2
+> = Migrator.make({
+  dumpSchema(path, table) {
+    // Additional behaviour goes to Effect.fnUntraced as arguments rather than
+    // through .pipe, which is what the generator form expects.
+    const mysqlDump = Effect.fnUntraced(function*(args: Array<string>) {
+      const sql = yield* MysqlClient
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+      const address = resolveAddress(sql.config)
+      const dump = yield* ChildProcess.make("mysqldump", [
+        "--host",
+        address.host,
+        "--port",
+        String(address.port),
+        ...(address.username === undefined ? [] : ["--user", address.username]),
+        "--skip-comments",
+        "--compact",
+        ...args,
+        ...(address.database === undefined ? [] : [address.database])
+      ], {
+        env: {
+          PATH: (globalThis as { readonly process?: { readonly env?: Record<string, string | undefined> } })
+            .process?.env?.PATH,
+          // The password goes through the environment rather than argv,
+          // which any other process on the host can read.
+          MYSQL_PWD: address.password
+        }
+      }).pipe(spawner.string)
+
+      return dump.replace(/^\/\*.*$/gm, "")
+        .replace(/\n{2,}/gm, "\n\n")
+        .trim()
+    }, Effect.mapError((error) => new Migrator.MigrationError({ kind: "Failed", message: error.message })))
+
+    const dumpSchema = mysqlDump(["--no-data"])
+
+    const dumpMigrations = mysqlDump(["--no-create-info", "--tables", table])
+
+    const dumpAll = Effect.map(
+      Effect.all([dumpSchema, dumpMigrations], { concurrency: 2 }),
+      ([schema, migrations]) => schema + "\n\n" + migrations
+    )
+
+    const dumpFile = Effect.fnUntraced(function*(file: string) {
+      const fs = yield* FileSystem.FileSystem
+      const path_ = yield* Path.Path
+      const dump = yield* dumpAll
+      yield* fs.makeDirectory(path_.dirname(file), { recursive: true })
+      yield* fs.writeFileString(file, dump)
+    }, Effect.mapError((error) => new Migrator.MigrationError({ kind: "Failed", message: error.message })))
+
+    return dumpFile(path)
+  }
+})
+
+/**
+ * Creates a layer that runs MySQL migrations during layer construction, including `mysqldump`-based schema dump support when requested.
+ *
+ * @category layers
+ * @since 4.0.0
+ */
+export const layer = <R>(
+  options: Migrator.MigratorOptions<R>
+): Layer.Layer<
+  never,
+  Migrator.MigrationError | SqlError,
+  | SqlClient
+  | MysqlClient
+  | ChildProcessSpawner.ChildProcessSpawner
+  | FileSystem.FileSystem
+  | Path.Path
+  | R
+> => Layer.effectDiscard(run(options))

--- a/packages/sql/mysql/src/MysqlPool.ts
+++ b/packages/sql/mysql/src/MysqlPool.ts
@@ -1,0 +1,201 @@
+/**
+ * Pools of native `MysqlConnection` sessions.
+ *
+ * @since 4.0.0
+ */
+import * as Clock from "effect/Clock"
+import * as Context from "effect/Context"
+import * as Duration from "effect/Duration"
+import * as Effect from "effect/Effect"
+import * as Pool from "effect/Pool"
+import type * as Scope from "effect/Scope"
+import type { SqlError } from "effect/unstable/sql/SqlError"
+import { connectionInternals } from "./internal/connection.ts"
+import * as MysqlConnection from "./MysqlConnection.ts"
+
+/**
+ * The runtime type identifier for `MysqlPool`.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export const TypeId: TypeId = "~@effect/sql-mysql/MysqlPool"
+
+/**
+ * The type-level identifier for `MysqlPool`.
+ *
+ * @category type IDs
+ * @since 4.0.0
+ */
+export type TypeId = "~@effect/sql-mysql/MysqlPool"
+
+/**
+ * Connection and sizing settings for a MySQL session pool.
+ *
+ * **Details**
+ *
+ * The defaults are 0 to 10 connections and a 10-second idle timeout.
+ * `connectionTTL` replaces connections that exceed the configured lifetime.
+ * Every connection is used at least once, so a TTL of zero disables reuse.
+ *
+ * Every checkout is exclusive: MySQL answers one command at a time, so there
+ * is no equivalent of the multiplexing a PostgreSQL pool can offer.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface Config extends MysqlConnection.Config {
+  readonly idleTimeout?: Duration.Input | undefined
+  readonly maxConnections?: number | undefined
+  readonly minConnections?: number | undefined
+  readonly connectionTTL?: Duration.Input | undefined
+}
+
+/**
+ * A MySQL session pool.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface MysqlPool {
+  readonly [TypeId]: TypeId
+  readonly config: Config
+  /** Checks out a session for exclusive use until the scope closes. */
+  readonly get: Effect.Effect<MysqlConnection.MysqlConnection, SqlError, Scope.Scope>
+  /**
+   * Lends a session for the duration of one effect and takes it back on any
+   * exit, without opening a scope for it.
+   *
+   * **Details**
+   *
+   * For work that finishes with the effect that runs it. A lease that has to
+   * outlive its effect - a stream, a transaction - takes `get`.
+   */
+  readonly use: <A, E, R>(
+    f: (connection: MysqlConnection.MysqlConnection) => Effect.Effect<A, E, R>
+  ) => Effect.Effect<A, E | SqlError, R>
+  /**
+   * Removes a session so the pool can replace it. Fatal protocol and socket
+   * errors invalidate sessions automatically.
+   */
+  readonly invalidate: (connection: MysqlConnection.MysqlConnection) => Effect.Effect<void>
+}
+
+/**
+ * The service tag for `MysqlPool`.
+ *
+ * @category services
+ * @since 4.0.0
+ */
+export const MysqlPool = Context.Service<MysqlPool>("@effect/sql-mysql/MysqlPool")
+
+/**
+ * Creates a scoped MySQL session pool.
+ *
+ * **Details**
+ *
+ * Connections are opened lazily up to `maxConnections` and released down to
+ * `minConnections` after `idleTimeout` without use. Closing the scope shuts
+ * the pool down and releases every session.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const make = Effect.fnUntraced(function*(options: Config): Effect.fn.Return<MysqlPool, SqlError, Scope.Scope> {
+  const clock = yield* Clock.Clock
+  const runFork = Effect.runForkWith(yield* Effect.context())
+
+  const connectionTTL = options.connectionTTL !== undefined
+    ? Duration.toMillis(Duration.fromInputUnsafe(options.connectionTTL))
+    : undefined
+  const deadConnections = new Set<MysqlConnection.MysqlConnection>()
+  const createdAt = new WeakMap<MysqlConnection.MysqlConnection, number>()
+  const checkedOut = new WeakSet<MysqlConnection.MysqlConnection>()
+
+  // Assigned below, once the pool exists. `acquire` only runs when the pool
+  // opens a connection, which is always after that.
+  let pool: Pool.Pool<MysqlConnection.MysqlConnection, SqlError>
+  const acquire = Effect.tap(MysqlConnection.make(options), (connection) =>
+    Effect.sync(() => {
+      createdAt.set(connection, clock.currentTimeMillisUnsafe())
+      connectionInternals(connection).fatalHooks.add(() => {
+        deadConnections.add(connection)
+        // `deadConnections` is only read by the next checkout, and a checkout
+        // already waiting for this connection would never get that far. Tell
+        // the pool now so it can replace the connection and admit them.
+        runFork(Pool.invalidate(pool, connection))
+      })
+    }))
+
+  pool = yield* Pool.makeWithTTL({
+    acquire,
+    min: options.minConnections ?? 0,
+    max: options.maxConnections ?? 10,
+    // MySQL numbers the packets of a command, so a session answers one command
+    // at a time and cannot be shared between fibers.
+    concurrency: 1,
+    timeToLive: options.idleTimeout ?? Duration.seconds(10),
+    timeToLiveStrategy: "usage"
+  })
+
+  const expired = (connection: MysqlConnection.MysqlConnection): boolean => {
+    if (connectionInternals(connection).isDead()) return true
+    if (connectionTTL === undefined) return false
+    if (!checkedOut.has(connection)) {
+      checkedOut.add(connection)
+      return false
+    }
+    const openedAt = createdAt.get(connection)
+    return openedAt !== undefined && clock.currentTimeMillisUnsafe() - openedAt >= connectionTTL
+  }
+
+  // A checkout runs per statement, so the case where nothing has died and the
+  // first connection is usable stays a plain flatMap; retrying is the
+  // exception and pays for the loop.
+  const retry: Effect.Effect<MysqlConnection.MysqlConnection, SqlError, Scope.Scope> = Effect.gen(function*() {
+    while (true) {
+      if (deadConnections.size > 0) {
+        const dead = Array.from(deadConnections)
+        deadConnections.clear()
+        yield* Effect.forEach(dead, (connection) => Pool.invalidate(pool, connection), { discard: true })
+      }
+      const connection = yield* Pool.get(pool)
+      if (expired(connection)) {
+        yield* Pool.invalidate(pool, connection)
+        continue
+      }
+      return connection
+    }
+  })
+
+  const get: Effect.Effect<MysqlConnection.MysqlConnection, SqlError, Scope.Scope> = Effect.suspend(() =>
+    deadConnections.size > 0 ? retry : Effect.flatMap(Pool.get(pool), (connection) =>
+      expired(connection)
+        ? Effect.andThen(Pool.invalidate(pool, connection), retry)
+        : Effect.succeed(connection))
+  )
+
+  // `Pool.use` cannot check the session it hands over before running the
+  // effect, so it is only taken when there is nothing to check: no session is
+  // known dead, and no lifetime can have run out. Otherwise the scoped
+  // checkout does its replacement pass first. Checking inside the callback
+  // instead would hold one lease while acquiring another, which deadlocks a
+  // pool of one.
+  const use = <A, E, R>(
+    f: (connection: MysqlConnection.MysqlConnection) => Effect.Effect<A, E, R>
+  ): Effect.Effect<A, E | SqlError, R> =>
+    Effect.suspend(() =>
+      connectionTTL === undefined && deadConnections.size === 0
+        ? Pool.use(pool, f)
+        : Effect.scoped(Effect.flatMap(get, f))
+    )
+
+  const mysqlPool: MysqlPool = {
+    [TypeId]: TypeId,
+    config: options,
+    get,
+    use,
+    invalidate: (connection) => Pool.invalidate(pool, connection)
+  }
+  return mysqlPool
+})

--- a/packages/sql/mysql/src/MysqlProtocol.ts
+++ b/packages/sql/mysql/src/MysqlProtocol.ts
@@ -1,0 +1,1548 @@
+/**
+ * The MySQL client/server protocol: constants, packet framing, and message
+ * codecs.
+ *
+ * Every function here is pure: bytes in, bytes or plain data out. Nothing here
+ * opens a socket, negotiates TLS, or tracks session state, and nothing here
+ * decodes column values.
+ *
+ * Unlike the PostgreSQL protocol, a MySQL packet does not name its own type. A
+ * payload beginning `0x00` is an OK packet in one phase of a command and a
+ * column count in another, so framing and interpretation are separate concerns:
+ * `makeParser` yields raw `Packet`s and the caller, which knows the phase,
+ * applies the matching decoder.
+ *
+ * @since 4.0.0
+ */
+import type * as Brand from "effect/Brand"
+import * as Data from "effect/Data"
+import * as Result from "effect/Result"
+import { BufferError, decodeUtf8, lengthOf, Reader, view, Writer } from "./internal/buffer.ts"
+import * as Flags from "./internal/flags.ts"
+import * as Field from "./internal/packet.ts"
+
+// -----------------------------------------------------------------------------
+// constants
+// -----------------------------------------------------------------------------
+
+/**
+ * The size in bytes of the header preceding every packet: a three-byte
+ * little-endian payload length followed by a one-byte sequence id.
+ *
+ * @category constants
+ * @since 4.0.0
+ */
+export const packetHeaderSize = 4
+
+/**
+ * The largest payload a single packet can carry. A payload of exactly this size
+ * is always followed by a continuation packet, so a logical message of 16 MiB
+ * arrives as two packets and an empty one terminates it.
+ *
+ * @category constants
+ * @since 4.0.0
+ */
+export const maxPacketPayload = 0xffffff
+
+/**
+ * Default `maxMessageSize` for `makeParser`: 64 MiB, after continuation packets
+ * are joined.
+ *
+ * @category constants
+ * @since 4.0.0
+ */
+export const defaultMaxMessageSize = 64 * 1024 * 1024
+
+/** Where a parser stops growing its buffer pool. */
+const maxBufferSize = 64 * 1024
+
+/**
+ * One capability a client and server may agree on.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type Capability = Brand.Branded<number, "MysqlCapability">
+
+/**
+ * The set of capabilities in force on a connection.
+ *
+ * **Gotchas**
+ *
+ * The wire field is 32 bits wide, so its two highest flags sit outside the
+ * range where JavaScript's bitwise operators stay positive. Going through this
+ * type keeps that arithmetic in one place; `capabilities & Capability.ssl`
+ * would silently return the wrong answer.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type Capabilities = Brand.Branded<number, "MysqlCapabilities">
+
+/**
+ * Operations on a set of capabilities.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export const Capabilities = {
+  none: 0 as Capabilities,
+  of: (flags: Iterable<Capability>): Capabilities => Flags.of(flags) as Capabilities,
+  has: (self: Capabilities, flag: Capability): boolean => Flags.has(self, flag),
+  add: (self: Capabilities, flag: Capability): Capabilities => Flags.add(self, flag) as Capabilities,
+  /** Keeps only the flags the other side also offers. */
+  retain: (self: Capabilities, flags: Iterable<Capability>): Capabilities => Flags.retain(self, flags) as Capabilities,
+  /** Rebuilds the set from the two halves the handshake sends separately. */
+  fromHalves: (lower: number, upper: number): Capabilities => (lower + upper * 0x10000) as Capabilities,
+  /** The value as it goes on the wire, reduced to 32 bits. */
+  wire: (self: Capabilities): number => self % 0x100000000
+} as const
+
+const capability = (value: number): Capability => value as Capability
+
+/**
+ * The capability flags this protocol knows.
+ *
+ * @category constants
+ * @since 4.0.0
+ */
+export const Capability = {
+  longPassword: capability(2 ** 0),
+  foundRows: capability(2 ** 1),
+  longFlag: capability(2 ** 2),
+  connectWithDb: capability(2 ** 3),
+  noSchema: capability(2 ** 4),
+  compress: capability(2 ** 5),
+  odbc: capability(2 ** 6),
+  localFiles: capability(2 ** 7),
+  ignoreSpace: capability(2 ** 8),
+  protocol41: capability(2 ** 9),
+  interactive: capability(2 ** 10),
+  ssl: capability(2 ** 11),
+  ignoreSigpipe: capability(2 ** 12),
+  transactions: capability(2 ** 13),
+  reserved: capability(2 ** 14),
+  secureConnection: capability(2 ** 15),
+  multiStatements: capability(2 ** 16),
+  multiResults: capability(2 ** 17),
+  psMultiResults: capability(2 ** 18),
+  pluginAuth: capability(2 ** 19),
+  connectAttrs: capability(2 ** 20),
+  pluginAuthLenencClientData: capability(2 ** 21),
+  canHandleExpiredPasswords: capability(2 ** 22),
+  sessionTrack: capability(2 ** 23),
+  deprecateEof: capability(2 ** 24),
+  optionalResultsetMetadata: capability(2 ** 25),
+  zstdCompressionAlgorithm: capability(2 ** 26),
+  queryAttributes: capability(2 ** 27),
+  multiFactorAuthentication: capability(2 ** 28),
+  capabilityExtension: capability(2 ** 29),
+  sslVerifyServerCert: capability(2 ** 30),
+  rememberOptions: capability(2 ** 31)
+} as const
+
+/**
+ * Command bytes that open a client request packet.
+ *
+ * @category constants
+ * @since 4.0.0
+ */
+export const Command = {
+  quit: 0x01,
+  initDb: 0x02,
+  query: 0x03,
+  ping: 0x0e,
+  stmtPrepare: 0x16,
+  stmtExecute: 0x17,
+  stmtSendLongData: 0x18,
+  stmtClose: 0x19,
+  stmtReset: 0x1a,
+  setOption: 0x1b,
+  stmtFetch: 0x1c,
+  resetConnection: 0x1f
+} as const
+
+/**
+ * Column type bytes carried in `ColumnDefinition41` and in binary rows.
+ *
+ * @category constants
+ * @since 4.0.0
+ */
+export const ColumnType = {
+  decimal: 0x00,
+  tiny: 0x01,
+  short: 0x02,
+  long: 0x03,
+  float: 0x04,
+  double: 0x05,
+  null: 0x06,
+  timestamp: 0x07,
+  longlong: 0x08,
+  int24: 0x09,
+  date: 0x0a,
+  time: 0x0b,
+  datetime: 0x0c,
+  year: 0x0d,
+  newdate: 0x0e,
+  varchar: 0x0f,
+  bit: 0x10,
+  json: 0xf5,
+  newdecimal: 0xf6,
+  enum: 0xf7,
+  set: 0xf8,
+  tinyBlob: 0xf9,
+  mediumBlob: 0xfa,
+  longBlob: 0xfb,
+  blob: 0xfc,
+  varString: 0xfd,
+  string: 0xfe,
+  geometry: 0xff
+} as const
+
+/**
+ * One flag on a column definition.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type ColumnFlag = Brand.Branded<number, "MysqlColumnFlag">
+
+/**
+ * The set of flags on a column definition.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type ColumnFlags = Brand.Branded<number, "MysqlColumnFlags">
+
+/**
+ * Operations on a column's flags.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export const ColumnFlags = {
+  none: 0 as ColumnFlags,
+  of: (flags: Iterable<ColumnFlag>): ColumnFlags => Flags.of(flags) as ColumnFlags,
+  has: (self: ColumnFlags, flag: ColumnFlag): boolean => Flags.has(self, flag)
+} as const
+
+const columnFlag = (value: number): ColumnFlag => value as ColumnFlag
+
+/**
+ * The column flags this protocol knows.
+ *
+ * @category constants
+ * @since 4.0.0
+ */
+export const ColumnFlag = {
+  notNull: columnFlag(2 ** 0),
+  priKey: columnFlag(2 ** 1),
+  uniqueKey: columnFlag(2 ** 2),
+  multipleKey: columnFlag(2 ** 3),
+  blob: columnFlag(2 ** 4),
+  unsigned: columnFlag(2 ** 5),
+  zerofill: columnFlag(2 ** 6),
+  binary: columnFlag(2 ** 7),
+  enum: columnFlag(2 ** 8),
+  autoIncrement: columnFlag(2 ** 9),
+  timestamp: columnFlag(2 ** 10),
+  set: columnFlag(2 ** 11),
+  noDefaultValue: columnFlag(2 ** 12),
+  onUpdateNow: columnFlag(2 ** 13),
+  num: columnFlag(2 ** 15)
+} as const
+
+/**
+ * One status flag reported by an OK or EOF packet.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type ServerStatusFlag = Brand.Branded<number, "MysqlServerStatusFlag">
+
+/**
+ * The server status reported by an OK or EOF packet.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type ServerStatus = Brand.Branded<number, "MysqlServerStatus">
+
+/**
+ * Operations on a reported server status.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export const ServerStatus = {
+  none: 0 as ServerStatus,
+  of: (flags: Iterable<ServerStatusFlag>): ServerStatus => Flags.of(flags) as ServerStatus,
+  has: (self: ServerStatus, flag: ServerStatusFlag): boolean => Flags.has(self, flag)
+} as const
+
+const serverStatusFlag = (value: number): ServerStatusFlag => value as ServerStatusFlag
+
+/**
+ * The status flags this protocol knows.
+ *
+ * @category constants
+ * @since 4.0.0
+ */
+export const ServerStatusFlag = {
+  inTransaction: serverStatusFlag(2 ** 0),
+  autocommit: serverStatusFlag(2 ** 1),
+  moreResultsExists: serverStatusFlag(2 ** 3),
+  noGoodIndexUsed: serverStatusFlag(2 ** 4),
+  noIndexUsed: serverStatusFlag(2 ** 5),
+  cursorExists: serverStatusFlag(2 ** 6),
+  lastRowSent: serverStatusFlag(2 ** 7),
+  dbDropped: serverStatusFlag(2 ** 8),
+  noBackslashEscapes: serverStatusFlag(2 ** 9),
+  metadataChanged: serverStatusFlag(2 ** 10),
+  queryWasSlow: serverStatusFlag(2 ** 11),
+  psOutParams: serverStatusFlag(2 ** 12),
+  inTransactionReadonly: serverStatusFlag(2 ** 13),
+  sessionStateChanged: serverStatusFlag(2 ** 14)
+} as const
+
+/**
+ * The collation id for the `binary` character set. A column reporting this
+ * collation holds bytes rather than text, which is the only way to tell
+ * `BINARY`, `VARBINARY` and `BLOB` apart from `CHAR`, `VARCHAR` and `TEXT`.
+ *
+ * @category constants
+ * @since 4.0.0
+ */
+export const binaryCollation = 63
+
+/**
+ * The collation id requested during the handshake. `utf8mb4_general_ci` keeps
+ * the connection on four-byte UTF-8 whatever the server default is.
+ *
+ * @category constants
+ * @since 4.0.0
+ */
+export const defaultCollation = 45
+
+/**
+ * Names of the authentication plugins this client implements.
+ *
+ * @category constants
+ * @since 4.0.0
+ */
+export const AuthPlugin = {
+  nativePassword: "mysql_native_password",
+  cachingSha2Password: "caching_sha2_password",
+  sha256Password: "sha256_password",
+  clearPassword: "mysql_clear_password"
+} as const
+
+// -----------------------------------------------------------------------------
+// errors
+// -----------------------------------------------------------------------------
+
+/**
+ * A malformed or truncated packet from the server.
+ *
+ * @category errors
+ * @since 4.0.0
+ */
+export class ParseError extends Data.TaggedError("MysqlProtocolParseError")<{
+  readonly message: string
+}> {}
+
+/**
+ * A value that cannot be represented on the wire.
+ *
+ * @category errors
+ * @since 4.0.0
+ */
+export class EncodeError extends Data.TaggedError("MysqlProtocolEncodeError")<{
+  readonly message: string
+}> {}
+
+const sharedWriter = new Writer(8192)
+const sharedReader = new Reader()
+
+const encodeResult = <A>(evaluate: () => A): Result.Result<A, EncodeError> => {
+  try {
+    return Result.succeed(evaluate())
+  } catch (error) {
+    if (error instanceof EncodeError) return Result.fail(error)
+    // The buffer reports running out of room without knowing which direction
+    // it was serving.
+    if (error instanceof BufferError) return Result.fail(new EncodeError({ message: error.message }))
+    throw error
+  }
+}
+
+const parseResult = <A>(evaluate: () => A): Result.Result<A, ParseError> => {
+  try {
+    return Result.succeed(evaluate())
+  } catch (error) {
+    if (error instanceof ParseError) return Result.fail(error)
+    if (error instanceof BufferError) return Result.fail(new ParseError({ message: error.message }))
+    throw error
+  }
+}
+
+// -----------------------------------------------------------------------------
+// framing
+// -----------------------------------------------------------------------------
+
+/**
+ * One protocol packet: its sequence id and its payload.
+ *
+ * **Gotchas**
+ *
+ * A payload is normally a view into the parser's buffer, so copying is the
+ * caller's job: one held beyond the current packet keeps its entire buffer in
+ * memory. A payload joined from continuation packets is already a copy.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface Packet {
+  readonly sequenceId: number
+  readonly payload: Uint8Array
+}
+
+/**
+ * An incremental decoder for the packet stream.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface Parser {
+  /**
+   * The sequence id the next packet must carry. The server restarts the count
+   * at zero for every command, so a client sending a command sets this to the
+   * id that follows its own request packet.
+   */
+  expectedSequenceId: number
+
+  /**
+   * Decodes a chunk and returns every complete packet. A partial packet is
+   * retained for the next call. Parse errors are terminal and discard packets
+   * decoded earlier in the same call.
+   */
+  readonly push: (chunk: Uint8Array) => ReadonlyArray<Packet>
+
+  /**
+   * Decodes a chunk and passes each complete packet to `onPacket` immediately,
+   * so a packet can change how the ones behind it in the same chunk are read.
+   * Packets delivered before a failure are not discarded.
+   */
+  readonly pushEach: (chunk: Uint8Array, onPacket: (packet: Packet) => void) => void
+}
+
+/**
+ * Creates a `Parser`.
+ *
+ * **Details**
+ *
+ * Continuation packets are joined transparently: a payload of exactly
+ * `maxPacketPayload` bytes is held back and concatenated with the packets that
+ * follow, so a caller only ever sees whole logical messages.
+ *
+ * @category constructors
+ * @since 4.0.0
+ */
+export const makeParser = (options?: {
+  readonly maxMessageSize?: number | undefined
+  readonly expectedSequenceId?: number | undefined
+}): Parser => {
+  const maxMessageSize = options?.maxMessageSize ?? defaultMaxMessageSize
+  let bufferSize = 8192
+  let buffer = new Uint8Array(bufferSize)
+  let store = buffer.buffer
+  let start = 0
+  let end = 0
+  let failed = false
+  let pendingParts: Array<Uint8Array> | undefined
+  let pendingLength = 0
+
+  // Bytes already handed to the caller are never overwritten, so a full buffer
+  // is replaced rather than compacted in place. That lets a payload be a view
+  // instead of a copy, which is the difference between one allocation per
+  // buffer and one per packet.
+  const append = (chunk: Uint8Array): void => {
+    if (end + chunk.length > buffer.length) {
+      const pending = end - start
+      if (bufferSize < maxBufferSize) bufferSize *= 2
+      let capacity = bufferSize
+      while (capacity < pending + chunk.length) capacity *= 2
+      const next = new Uint8Array(capacity)
+      next.set(buffer.subarray(start, end))
+      buffer = next
+      store = next.buffer
+      start = 0
+      end = pending
+    }
+    buffer.set(chunk, end)
+    end += chunk.length
+  }
+
+  const parser: Parser = {
+    expectedSequenceId: options?.expectedSequenceId ?? 0,
+    push(chunk) {
+      const packets: Array<Packet> = []
+      parser.pushEach(chunk, (packet) => {
+        packets.push(packet)
+      })
+      return packets
+    },
+    pushEach(chunk, onPacket) {
+      if (failed) {
+        throw new ParseError({ message: "Parser cannot be reused after a failure" })
+      }
+      try {
+        append(chunk)
+        while (end - start >= packetHeaderSize) {
+          const length = buffer[start] | (buffer[start + 1] << 8) | (buffer[start + 2] << 16)
+          if (end - start < packetHeaderSize + length) break
+          const sequenceId = buffer[start + 3]
+          if (sequenceId !== parser.expectedSequenceId) {
+            throw new ParseError({
+              message: `Out-of-order packet: expected sequence id ${parser.expectedSequenceId}, got ${sequenceId}`
+            })
+          }
+          parser.expectedSequenceId = (sequenceId + 1) & 0xff
+          // `buffer` always starts at byte 0 of `store`, so offsets index both.
+          const body = start + packetHeaderSize
+          start = body + length
+          if (length === maxPacketPayload) {
+            pendingLength += length
+            if (pendingLength > maxMessageSize) {
+              throw new ParseError({
+                message: `Message length ${pendingLength} exceeds maxMessageSize ${maxMessageSize}`
+              })
+            }
+            pendingParts ??= []
+            pendingParts.push(view(store, body, length))
+            continue
+          }
+          if (pendingParts === undefined) {
+            onPacket({ sequenceId, payload: view(store, body, length) })
+            continue
+          }
+          pendingLength += length
+          if (pendingLength > maxMessageSize) {
+            throw new ParseError({
+              message: `Message length ${pendingLength} exceeds maxMessageSize ${maxMessageSize}`
+            })
+          }
+          const joined = new Uint8Array(pendingLength)
+          let offset = 0
+          for (const part of pendingParts) {
+            joined.set(part, offset)
+            offset += part.length
+          }
+          joined.set(view(store, body, length), offset)
+          pendingParts = undefined
+          pendingLength = 0
+          onPacket({ sequenceId, payload: joined })
+        }
+      } catch (error) {
+        failed = true
+        throw error
+      }
+    }
+  }
+  return parser
+}
+
+/**
+ * Frames a payload into one or more packets, starting at `sequenceId`.
+ *
+ * **Details**
+ *
+ * A payload of `maxPacketPayload` bytes or more is split, and a payload whose
+ * length is an exact multiple of `maxPacketPayload` is terminated by an empty
+ * packet, which is how the server tells a split message from a complete one.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const frame = (payload: Uint8Array, sequenceId = 0): Uint8Array => {
+  const total = payload.length
+  const packets = Math.floor(total / maxPacketPayload) + 1
+  const output = new Uint8Array(total + packetHeaderSize * packets)
+  let read = 0
+  let write = 0
+  let sequence = sequenceId
+  for (let index = 0; index < packets; index++) {
+    const size = Math.min(maxPacketPayload, total - read)
+    output[write] = size
+    output[write + 1] = size >>> 8
+    output[write + 2] = size >>> 16
+    output[write + 3] = sequence
+    write += packetHeaderSize
+    if (size > 0) {
+      output.set(payload.subarray(read, read + size), write)
+      read += size
+      write += size
+    }
+    sequence = (sequence + 1) & 0xff
+  }
+  return output
+}
+
+/**
+ * Frames a command byte and its body into a request, starting at sequence id
+ * zero.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const encodeCommand = (command: number, body?: Uint8Array | string | undefined): Uint8Array => {
+  sharedWriter.begin()
+  sharedWriter.uint8(command)
+  if (typeof body === "string") sharedWriter.utf8(body)
+  else if (body !== undefined) sharedWriter.raw(body)
+  return frame(sharedWriter.finish())
+}
+
+/**
+ * Frames a `COM_QUERY` request carrying a text statement.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const encodeQuery = (sql: string): Uint8Array => encodeCommand(Command.query, sql)
+
+/**
+ * Frames a `COM_PING` request.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const encodePing = (): Uint8Array => encodeCommand(Command.ping)
+
+/**
+ * Frames a `COM_QUIT` request.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const encodeQuit = (): Uint8Array => encodeCommand(Command.quit)
+
+/**
+ * Frames a `COM_INIT_DB` request selecting a default schema.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const encodeInitDb = (database: string): Uint8Array => encodeCommand(Command.initDb, database)
+
+/**
+ * Frames a `COM_RESET_CONNECTION` request, which clears session state without
+ * reauthenticating.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const encodeResetConnection = (): Uint8Array => encodeCommand(Command.resetConnection)
+
+// -----------------------------------------------------------------------------
+// response classification
+// -----------------------------------------------------------------------------
+
+/**
+ * What the first packet of a command's reply turns out to be.
+ *
+ * **Details**
+ *
+ * A reply begins in exactly one of these shapes, so reading it is a matter of
+ * naming which, rather than of consulting a classifier that has to be right in
+ * every position.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type Response = Data.TaggedEnum<{
+  readonly Ok: { readonly ok: Ok }
+  readonly Error: { readonly error: Err }
+  readonly LocalInfile: {}
+  readonly ResultSet: { readonly columnCount: number }
+}>
+
+/**
+ * Constructors and guards for `Response`.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export const Response = Data.taggedEnum<Response>()
+
+/**
+ * What a packet turns out to be where a row is expected.
+ *
+ * **Gotchas**
+ *
+ * The bytes that open a row overlap with the bytes that open other packets:
+ * `0x00` starts a row whose first column is an empty string, and `0xfb` one
+ * whose first column is NULL. Neither is an OK packet or a LOCAL INFILE
+ * request, which is why this is a separate decoder rather than a shared one.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type RowPacket = Data.TaggedEnum<{
+  readonly Row: { readonly payload: Uint8Array }
+  readonly End: { readonly ok: Ok }
+  readonly Error: { readonly error: Err }
+}>
+
+/**
+ * Constructors and guards for `RowPacket`.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export const RowPacket = Data.taggedEnum<RowPacket>()
+
+/**
+ * A terminator is `0xfe` in a payload too short to be a value, since `0xfe` as
+ * a length prefix is followed by eight more bytes.
+ */
+const isTerminator = (payload: Uint8Array): boolean => payload.length > 0 && payload[0] === 0xfe && payload.length < 9
+
+/**
+ * Whether a packet is an ERR.
+ *
+ * **Details**
+ *
+ * `0xff` never opens a length-encoded value, so unlike the OK and EOF headers
+ * this one is unambiguous in any position — including before the handshake,
+ * where a server that refuses the connection outright sends an ERR in place
+ * of its greeting.
+ *
+ * @category predicates
+ * @since 4.0.0
+ */
+export const isErr = (payload: Uint8Array): boolean => payload.length > 0 && payload[0] === 0xff
+
+/**
+ * Reads the packet that opens a command's reply.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const decodeResponse = (payload: Uint8Array): Result.Result<Response, ParseError> => {
+  if (isErr(payload)) {
+    return Result.map(decodeErr(payload), (error) => Response.Error({ error }))
+  }
+  if (payload.length > 0 && (payload[0] === 0x00 || isTerminator(payload))) {
+    return Result.map(decodeOk(payload), (ok) => Response.Ok({ ok }))
+  }
+  // 0xfb only means LOCAL INFILE here: it is not a valid column count, and in
+  // a row it is simply SQL NULL.
+  if (payload.length > 0 && payload[0] === 0xfb) {
+    return Result.succeed(Response.LocalInfile())
+  }
+  return parseResult(() => {
+    const count = columnCount(payload)
+    if (count === undefined) throw new ParseError({ message: "Malformed result set header" })
+    return Response.ResultSet({ columnCount: count })
+  })
+}
+
+/**
+ * Reads a packet where a row is expected.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const decodeRow = (payload: Uint8Array): Result.Result<RowPacket, ParseError> => {
+  if (isErr(payload)) {
+    return Result.map(decodeErr(payload), (error) => RowPacket.Error({ error }))
+  }
+  if (isTerminator(payload)) {
+    return Result.map(decodeOk(payload), (ok) => RowPacket.End({ ok }))
+  }
+  return Result.succeed(RowPacket.Row({ payload }))
+}
+
+/** Reads the length-encoded column count that opens a result set. */
+const columnCount = (payload: Uint8Array): number | undefined => {
+  if (payload.length === 0) return undefined
+  const first = payload[0]
+  if (first < 0xfb) return payload.length === 1 ? first : undefined
+  if (first === 0xfc && payload.length === 3) return payload[1] | (payload[2] << 8)
+  if (first === 0xfd && payload.length === 4) return payload[1] | (payload[2] << 8) | (payload[3] << 16)
+  return undefined
+}
+
+// -----------------------------------------------------------------------------
+// decoding
+// -----------------------------------------------------------------------------
+
+/**
+ * A successful command result.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface Ok {
+  readonly affectedRows: number | bigint
+  readonly lastInsertId: number | bigint
+  readonly statusFlags: ServerStatus
+  readonly warnings: number
+  readonly info: string
+}
+
+const okPacket = Field.decoder({
+  header: Field.tag(0x00, 0xfe),
+  affectedRows: Field.lenencInt,
+  lastInsertId: Field.lenencInt,
+  statusFlags: Field.uint16,
+  warnings: Field.uint16,
+  // The trailing human-readable info is optional, and its shape depends on
+  // CLIENT_SESSION_TRACK, which this client does not negotiate.
+  info: Field.whenPresent(Field.restString)
+})
+
+/**
+ * Decodes an OK packet.
+ *
+ * **Details**
+ *
+ * With `CLIENT_DEPRECATE_EOF` negotiated the end of a result set is also an OK
+ * packet, distinguished only by its `0xfe` header byte, so both headers are
+ * accepted here.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const decodeOk = (payload: Uint8Array): Result.Result<Ok, ParseError> =>
+  parseResult(() => {
+    const fields = okPacket(sharedReader, payload)
+    if (fields.affectedRows === null || fields.lastInsertId === null) {
+      throw new ParseError({ message: "OK packet has a null length-encoded integer" })
+    }
+    return {
+      affectedRows: fields.affectedRows,
+      lastInsertId: fields.lastInsertId,
+      statusFlags: fields.statusFlags as ServerStatus,
+      warnings: fields.warnings,
+      info: fields.info ?? ""
+    }
+  })
+
+/**
+ * A server error response.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface Err {
+  readonly code: number
+  readonly sqlState: string | undefined
+  readonly message: string
+}
+
+const errPacket = Field.decoder({
+  header: Field.tag(0xff),
+  code: Field.uint16,
+  // The marker and state are only present under CLIENT_PROTOCOL_41, and are
+  // absent from the ERR packet that can arrive before capabilities are agreed.
+  sqlState: Field.whenByte(
+    0x23,
+    Field.make((reader) => {
+      reader.skip(1)
+      return reader.string(5)
+    })
+  ),
+  message: Field.restString
+})
+
+/**
+ * Decodes an ERR packet.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const decodeErr = (payload: Uint8Array): Result.Result<Err, ParseError> =>
+  parseResult(() => {
+    const fields = errPacket(sharedReader, payload)
+    return { code: fields.code, sqlState: fields.sqlState, message: fields.message }
+  })
+
+/**
+ * The legacy end-of-result marker, sent only when `CLIENT_DEPRECATE_EOF` was
+ * not negotiated.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface Eof {
+  readonly warnings: number
+  readonly statusFlags: ServerStatus
+}
+
+const eofPacket = Field.decoder({
+  header: Field.tag(0xfe),
+  warnings: Field.uint16,
+  statusFlags: Field.uint16
+})
+
+/**
+ * Decodes a legacy EOF packet.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const decodeEof = (payload: Uint8Array): Result.Result<Eof, ParseError> =>
+  parseResult(() => {
+    const fields = eofPacket(sharedReader, payload)
+    return { warnings: fields.warnings, statusFlags: fields.statusFlags as ServerStatus }
+  })
+
+/**
+ * A column of a result set.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface Column {
+  readonly schema: string
+  readonly table: string
+  readonly orgTable: string
+  readonly name: string
+  readonly orgName: string
+  readonly collation: number
+  readonly columnLength: number
+  readonly type: number
+  readonly flags: ColumnFlags
+  readonly decimals: number
+}
+
+/**
+ * Questions worth asking of a column, so callers do not read its bits.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export const Column = {
+  /**
+   * Whether the column holds bytes rather than text. The binary collation is
+   * the only thing separating `BLOB` from `TEXT`, which share a type byte.
+   */
+  isBinary: (column: Column): boolean => column.collation === binaryCollation,
+  isUnsigned: (column: Column): boolean => ColumnFlags.has(column.flags, ColumnFlag.unsigned)
+} as const
+
+const columnPacket = Field.decoder({
+  catalog: Field.lenencString,
+  schema: Field.lenencString,
+  table: Field.lenencString,
+  orgTable: Field.lenencString,
+  name: Field.lenencString,
+  orgName: Field.lenencString,
+  fixedLength: Field.lenencInt,
+  collation: Field.uint16,
+  columnLength: Field.uint32,
+  type: Field.uint8,
+  flags: Field.uint16,
+  decimals: Field.uint8
+})
+
+/**
+ * Decodes a `ColumnDefinition41` packet.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const decodeColumn = (payload: Uint8Array): Result.Result<Column, ParseError> =>
+  parseResult(() => {
+    const fields = columnPacket(sharedReader, payload)
+    if (fields.fixedLength === null || lengthOf(fields.fixedLength) < 0x0c) {
+      throw new ParseError({ message: "Column definition has a short fixed-length block" })
+    }
+    return {
+      schema: fields.schema ?? "",
+      table: fields.table ?? "",
+      orgTable: fields.orgTable ?? "",
+      name: fields.name ?? "",
+      orgName: fields.orgName ?? "",
+      collation: fields.collation,
+      columnLength: fields.columnLength,
+      type: fields.type,
+      flags: fields.flags as ColumnFlags,
+      decimals: fields.decimals
+    }
+  })
+
+/**
+ * Reads one field of a row.
+ *
+ * **Gotchas**
+ *
+ * `size` is `-1` for SQL NULL, in which case `bytes` and `offset` carry no
+ * meaning. `bytes` is the parser's own buffer, so a reader that keeps the value
+ * beyond the current row has to copy it.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type FieldReader<A> = (bytes: Uint8Array, offset: number, size: number, column: number) => A
+
+/**
+ * Decodes a text-protocol row, the row format `COM_QUERY` returns.
+ *
+ * **Details**
+ *
+ * Every field arrives as a length-encoded string, so no column metadata is
+ * needed to walk the row; converting a field to a typed value is the
+ * `readField` reader's job.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const decodeTextRow = <A>(
+  payload: Uint8Array,
+  columnCount: number,
+  readField: FieldReader<A>
+): Result.Result<Array<A>, ParseError> =>
+  parseResult(() => {
+    const limit = payload.length
+    const row = new Array<A>(columnCount)
+    let offset = 0
+    for (let column = 0; column < columnCount; column++) {
+      if (offset >= limit) {
+        throw new ParseError({ message: `Truncated row: expected ${columnCount} column(s), got ${column}` })
+      }
+      const first = payload[offset]
+      if (first === 0xfb) {
+        offset += 1
+        row[column] = readField(payload, 0, -1, column)
+        continue
+      }
+      let size: number
+      if (first < 0xfb) {
+        size = first
+        offset += 1
+      } else if (first === 0xfc) {
+        size = payload[offset + 1] | (payload[offset + 2] << 8)
+        offset += 3
+      } else if (first === 0xfd) {
+        size = payload[offset + 1] | (payload[offset + 2] << 8) | (payload[offset + 3] << 16)
+        offset += 4
+      } else {
+        sharedReader.reset(payload, offset, limit)
+        const value = sharedReader.lenencInt()
+        if (value === null) throw new ParseError({ message: "Unexpected null length in a row" })
+        size = lengthOf(value)
+        offset = sharedReader.offset
+      }
+      if (offset + size > limit) {
+        throw new ParseError({ message: `Truncated field: column ${column} claims ${size} byte(s)` })
+      }
+      row[column] = readField(payload, offset, size, column)
+      offset += size
+    }
+    if (offset !== limit) {
+      throw new ParseError({ message: `Row has ${limit - offset} trailing byte(s)` })
+    }
+    return row
+  })
+
+/**
+ * Reads a field as a view over the parser's buffer, or `null` for SQL NULL.
+ * This is the default reader, and the one to use when the caller copies or
+ * decodes fields itself.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const readFieldBytes: FieldReader<Uint8Array | null> = (bytes, offset, size) =>
+  size === -1 ? null : view(bytes.buffer, bytes.byteOffset + offset, size)
+
+/**
+ * Reads a field as a UTF-8 string, or `null` for SQL NULL.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const readFieldString: FieldReader<string | null> = (bytes, offset, size) =>
+  size === -1 ? null : decodeUtf8(bytes, offset, size)
+
+/**
+ * Writes bytes with the protocol's own primitives, for building fixtures and
+ * request payloads a named encoder does not cover.
+ *
+ * **Gotchas**
+ *
+ * Each call gets a writer of its own, so nesting two of them is safe. The
+ * named encoders share one writer and are not reentrant, which is why this
+ * does not reuse it.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const encodeWith = (
+  write: (writer: {
+    readonly uint8: (value: number) => void
+    readonly uint16: (value: number) => void
+    readonly uint24: (value: number) => void
+    readonly uint32: (value: number) => void
+    readonly uint64: (value: bigint) => void
+    readonly lenencInt: (value: number | bigint) => void
+    readonly lenencString: (value: string) => void
+    readonly lenencBytes: (value: Uint8Array) => void
+    readonly raw: (value: Uint8Array) => void
+    readonly fill: (byte: number, count: number) => void
+    readonly utf8: (value: string, nul?: boolean) => void
+    readonly cString: (value: string) => void
+  }) => void
+): Result.Result<Uint8Array, EncodeError> =>
+  encodeResult(() => {
+    const writer = new Writer(256)
+    write(writer)
+    return writer.finish()
+  })
+
+// -----------------------------------------------------------------------------
+// handshake
+// -----------------------------------------------------------------------------
+
+/**
+ * The maximum packet size the client advertises. Framing already caps a single
+ * packet at `maxPacketPayload`, and larger messages are split, so this is the
+ * ceiling on one packet rather than on one result.
+ *
+ * @category constants
+ * @since 4.0.0
+ */
+export const maxAllowedPacket = 0xffffff
+
+/**
+ * The server's opening message, sent before the client says anything.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface Handshake {
+  readonly protocolVersion: number
+  readonly serverVersion: string
+  readonly connectionId: number
+  readonly capabilities: Capabilities
+  readonly collation: number
+  readonly statusFlags: ServerStatus
+  /** The 20-byte challenge, joined from the two halves the server sends. */
+  readonly scramble: Uint8Array
+  readonly authPlugin: string
+}
+
+/**
+ * The part of the greeting every server sends. What follows it depends on a
+ * length the greeting itself carries, so it is read separately.
+ */
+const handshakeHead = Field.decoder({
+  protocolVersion: Field.make((reader) => {
+    const version = reader.uint8()
+    if (version !== 10) {
+      throw new BufferError({ message: `Unsupported handshake protocol version ${version}` })
+    }
+    return version
+  }),
+  serverVersion: Field.cString,
+  connectionId: Field.uint32,
+  scrambleHead: Field.bytes(8),
+  filler: Field.skip(1),
+  capabilityLower: Field.uint16
+})
+
+/**
+ * Decodes the server's `HandshakeV10` packet.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const decodeHandshake = (payload: Uint8Array): Result.Result<Handshake, ParseError> =>
+  parseResult(() => {
+    const reader = sharedReader
+    const head = handshakeHead(reader, payload)
+    // A pre-4.1 server stops here. Nothing this client supports does, but the
+    // greeting is the one packet that arrives before capabilities are known.
+    if (reader.offset >= reader.limit) {
+      return {
+        protocolVersion: head.protocolVersion,
+        serverVersion: head.serverVersion,
+        connectionId: head.connectionId,
+        capabilities: head.capabilityLower as Capabilities,
+        collation: 0,
+        statusFlags: ServerStatus.none,
+        scramble: head.scrambleHead,
+        authPlugin: ""
+      }
+    }
+    const collation = reader.uint8()
+    const statusFlags = reader.uint16() as ServerStatus
+    const capabilityUpper = reader.uint16()
+    const scrambleLength = reader.uint8()
+    reader.skip(10) // reserved
+    // The second half is padded to at least 13 bytes and carries a trailing NUL
+    // that is not part of the challenge, so its length comes from the greeting
+    // rather than from the bytes on the wire.
+    const tailLength = Math.max(13, scrambleLength - 8)
+    const tail = reader.raw(tailLength)
+    const tailUsed = Math.max(0, Math.min(tailLength, scrambleLength - 8) - 1)
+    const scramble = new Uint8Array(head.scrambleHead.length + tailUsed)
+    scramble.set(head.scrambleHead)
+    scramble.set(tail.subarray(0, tailUsed), head.scrambleHead.length)
+    return {
+      protocolVersion: head.protocolVersion,
+      serverVersion: head.serverVersion,
+      connectionId: head.connectionId,
+      capabilities: Capabilities.fromHalves(head.capabilityLower, capabilityUpper),
+      collation,
+      statusFlags,
+      scramble,
+      authPlugin: reader.offset < reader.limit ? reader.cString() : ""
+    }
+  })
+
+/**
+ * Frames the 32-byte `SSLRequest`, which is the header of a handshake response
+ * and nothing else. The client upgrades the socket to TLS straight after
+ * writing it and then sends the full response over the encrypted connection.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const encodeSslRequest = (options: {
+  readonly capabilities: Capabilities
+  readonly collation: number
+  readonly sequenceId: number
+}): Uint8Array => {
+  sharedWriter.begin()
+  sharedWriter.uint32(Capabilities.wire(options.capabilities))
+  sharedWriter.uint32(maxAllowedPacket)
+  sharedWriter.uint8(options.collation)
+  sharedWriter.fill(0, 23)
+  return frame(sharedWriter.finish(), options.sequenceId)
+}
+
+/**
+ * Frames a `HandshakeResponse41`.
+ *
+ * **Gotchas**
+ *
+ * The auth response is written length-encoded, which requires the client to
+ * have set `pluginAuthLenencClientData` in `capabilities`.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const encodeHandshakeResponse = (options: {
+  readonly capabilities: Capabilities
+  readonly collation: number
+  readonly username: string
+  readonly authResponse: Uint8Array
+  readonly database: string | undefined
+  readonly authPlugin: string
+  readonly sequenceId: number
+}): Uint8Array => {
+  sharedWriter.begin()
+  sharedWriter.uint32(Capabilities.wire(options.capabilities))
+  sharedWriter.uint32(maxAllowedPacket)
+  sharedWriter.uint8(options.collation)
+  sharedWriter.fill(0, 23)
+  sharedWriter.cString(options.username)
+  sharedWriter.lenencBytes(options.authResponse)
+  if (options.database !== undefined) sharedWriter.cString(options.database)
+  sharedWriter.cString(options.authPlugin)
+  return frame(sharedWriter.finish(), options.sequenceId)
+}
+
+/**
+ * The server's request to continue authenticating with a different plugin.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface AuthSwitchRequest {
+  readonly plugin: string
+  readonly scramble: Uint8Array
+}
+
+const authSwitchPacket = Field.decoder({
+  header: Field.tag(0xfe),
+  plugin: Field.cString,
+  challenge: Field.rest
+})
+
+/**
+ * Decodes an `AuthSwitchRequest` packet.
+ *
+ * **Gotchas**
+ *
+ * This shares its `0xfe` header byte with EOF, so only decode it where the
+ * handshake expects one.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const decodeAuthSwitchRequest = (payload: Uint8Array): Result.Result<AuthSwitchRequest, ParseError> =>
+  parseResult(() => {
+    const fields = authSwitchPacket(sharedReader, payload)
+    const challenge = fields.challenge
+    // The challenge carries a trailing NUL that is not part of it.
+    const scramble = challenge.length > 0 && challenge[challenge.length - 1] === 0
+      ? challenge.subarray(0, challenge.length - 1)
+      : challenge
+    return { plugin: fields.plugin, scramble }
+  })
+
+/**
+ * Decodes an `AuthMoreData` packet, returning the plugin-specific payload that
+ * follows its `0x01` header.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const decodeAuthMoreData = (payload: Uint8Array): Result.Result<Uint8Array, ParseError> =>
+  parseResult(() => {
+    if (payload.length === 0 || payload[0] !== 0x01) {
+      throw new ParseError({ message: "Expected an AuthMoreData packet" })
+    }
+    return payload.subarray(1)
+  })
+
+/**
+ * Frames a raw authentication payload, used for the replies that continue an
+ * exchange after the initial handshake response.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const encodeAuthData = (data: Uint8Array, sequenceId: number): Uint8Array => frame(data, sequenceId)
+
+// -----------------------------------------------------------------------------
+// prepared statements
+// -----------------------------------------------------------------------------
+
+/**
+ * What the server reports about a statement it has prepared.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface StmtPrepareOk {
+  readonly statementId: number
+  readonly columnCount: number
+  readonly parameterCount: number
+  readonly warnings: number
+}
+
+const stmtPreparePacket = Field.decoder({
+  header: Field.tag(0x00),
+  statementId: Field.uint32,
+  columnCount: Field.uint16,
+  parameterCount: Field.uint16,
+  reserved: Field.skip(1),
+  warnings: Field.whenPresent(Field.uint16)
+})
+
+/**
+ * Decodes the reply to `COM_STMT_PREPARE`.
+ *
+ * **Details**
+ *
+ * `parameterCount` column definitions follow, then `columnCount` of them. With
+ * `CLIENT_DEPRECATE_EOF` negotiated there is no EOF packet between or after
+ * the two groups.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const decodeStmtPrepareOk = (payload: Uint8Array): Result.Result<StmtPrepareOk, ParseError> =>
+  parseResult(() => {
+    const fields = stmtPreparePacket(sharedReader, payload)
+    return {
+      statementId: fields.statementId,
+      columnCount: fields.columnCount,
+      parameterCount: fields.parameterCount,
+      warnings: fields.warnings ?? 0
+    }
+  })
+
+/**
+ * Frames a `COM_STMT_PREPARE` request.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const encodeStmtPrepare = (sql: string): Uint8Array => encodeCommand(Command.stmtPrepare, sql)
+
+/**
+ * Frames a `COM_STMT_CLOSE` request.
+ *
+ * **Gotchas**
+ *
+ * The server sends no reply, so a caller must not wait for one.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const encodeStmtClose = (statementId: number): Uint8Array => {
+  sharedWriter.begin()
+  sharedWriter.uint8(Command.stmtClose)
+  sharedWriter.uint32(statementId)
+  return frame(sharedWriter.finish())
+}
+
+/**
+ * Frames a `COM_STMT_RESET` request, which drops the data a statement has
+ * accumulated without closing it.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const encodeStmtReset = (statementId: number): Uint8Array => {
+  sharedWriter.begin()
+  sharedWriter.uint8(Command.stmtReset)
+  sharedWriter.uint32(statementId)
+  return frame(sharedWriter.finish())
+}
+
+/**
+ * Writes one parameter value into a `COM_STMT_EXECUTE` request.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface ValueSink {
+  readonly uint8: (value: number) => void
+  readonly uint16: (value: number) => void
+  readonly uint32: (value: number) => void
+  readonly uint64: (value: bigint) => void
+  readonly int64: (value: bigint) => void
+  readonly float32: (value: number) => void
+  readonly float64: (value: number) => void
+  readonly lenencString: (value: string) => void
+  readonly lenencBytes: (value: Uint8Array) => void
+  readonly raw: (value: Uint8Array) => void
+}
+
+/**
+ * A parameter bound to a prepared statement: its wire type, its signedness,
+ * and how to write it.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface BoundParameter {
+  readonly type: number
+  readonly unsigned: boolean
+  /** Writes the value, or `undefined` for SQL NULL. */
+  readonly write: ((sink: ValueSink) => void) | undefined
+}
+
+/**
+ * Frames a `COM_STMT_EXECUTE` request.
+ *
+ * **Details**
+ *
+ * Parameters are laid out in two groups: a null bitmap and one `(type,
+ * unsigned)` pair per parameter, then the values of the parameters that are
+ * not null. The layout assumes `CLIENT_QUERY_ATTRIBUTES` was not negotiated,
+ * which is what this client does.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const encodeStmtExecute = (options: {
+  readonly statementId: number
+  readonly parameters: ReadonlyArray<BoundParameter>
+}): Uint8Array => {
+  const parameters = options.parameters
+  sharedWriter.begin()
+  sharedWriter.uint8(Command.stmtExecute)
+  sharedWriter.uint32(options.statementId)
+  sharedWriter.uint8(0) // CURSOR_TYPE_NO_CURSOR
+  sharedWriter.uint32(1) // iteration count, always one
+  if (parameters.length > 0) {
+    const bitmapSize = (parameters.length + 7) >> 3
+    const bitmap = new Uint8Array(bitmapSize)
+    for (let index = 0; index < parameters.length; index++) {
+      if (parameters[index].write === undefined) bitmap[index >> 3] |= 1 << (index & 7)
+    }
+    sharedWriter.raw(bitmap)
+    sharedWriter.uint8(1) // the types that follow are being (re)bound
+    for (const parameter of parameters) {
+      sharedWriter.uint8(parameter.type)
+      sharedWriter.uint8(parameter.unsigned ? 0x80 : 0x00)
+    }
+    for (const parameter of parameters) {
+      parameter.write?.(sharedWriter)
+    }
+  }
+  return frame(sharedWriter.finish())
+}
+
+/**
+ * Reads one field of a binary row, returning its value and the offset just
+ * past it. Unlike a text field, a binary field's width comes from its column
+ * type rather than a length prefix, so the reader reports how far it read.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export type BinaryFieldReader<A> = (
+  bytes: Uint8Array,
+  offset: number,
+  limit: number,
+  column: number
+) => readonly [value: A, next: number]
+
+/**
+ * Decodes a binary-protocol row, the row format `COM_STMT_EXECUTE` returns.
+ *
+ * **Details**
+ *
+ * A binary row opens with `0x00` and a null bitmap whose bits are offset by
+ * two, so column `n` is bit `n + 2`. Only the columns the bitmap leaves unset
+ * are passed to `readField`.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const decodeBinaryRow = <A>(
+  payload: Uint8Array,
+  columnCount: number,
+  readField: BinaryFieldReader<A>
+): Result.Result<Array<A | null>, ParseError> =>
+  parseResult(() => {
+    if (payload.length === 0 || payload[0] !== 0x00) {
+      throw new ParseError({ message: "Expected a binary row" })
+    }
+    const bitmapSize = (columnCount + 9) >> 3
+    if (payload.length < 1 + bitmapSize) {
+      throw new ParseError({ message: "Truncated binary row: the null bitmap does not fit" })
+    }
+    const row = new Array<A | null>(columnCount)
+    const limit = payload.length
+    let offset = 1 + bitmapSize
+    for (let column = 0; column < columnCount; column++) {
+      // The bitmap reserves its first two bits, so column n is bit n + 2.
+      const bit = column + 2
+      if ((payload[1 + (bit >> 3)] & (1 << (bit & 7))) !== 0) {
+        row[column] = null
+        continue
+      }
+      const [value, next] = readField(payload, offset, limit, column)
+      if (next > limit || next < offset) {
+        throw new ParseError({ message: `Truncated binary row at column ${column}` })
+      }
+      row[column] = value
+      offset = next
+    }
+    if (offset !== limit) {
+      throw new ParseError({ message: `Binary row has ${limit - offset} trailing byte(s)` })
+    }
+    return row
+  })

--- a/packages/sql/mysql/src/MysqlTypes.ts
+++ b/packages/sql/mysql/src/MysqlTypes.ts
@@ -1,0 +1,689 @@
+/**
+ * Converting MySQL column values to JavaScript values.
+ *
+ * MySQL sends a column's type in its definition and its value in one of two
+ * formats: the text protocol writes every value as a string, and the binary
+ * protocol writes typed bytes. Both formats decode to the same JavaScript
+ * value, so the mapping is decided once here and each format reads it.
+ *
+ * Unlike PostgreSQL, MySQL has a closed type space: there are no user-defined
+ * types on the wire, so there is no codec registry to extend. What is
+ * configurable is the handful of choices where no single answer suits every
+ * caller, which `DecodeOptions` collects.
+ *
+ * @since 4.0.0
+ */
+import * as Data from "effect/Data"
+import * as Result from "effect/Result"
+import * as MysqlProtocol from "./MysqlProtocol.ts"
+
+/**
+ * A value that cannot be represented, in either direction.
+ *
+ * @category errors
+ * @since 4.0.0
+ */
+export class CodecError extends Data.TaggedError("MysqlCodecError")<{
+  readonly message: string
+}> {}
+
+/**
+ * The choices where no single mapping suits every caller.
+ *
+ * @category models
+ * @since 4.0.0
+ */
+export interface DecodeOptions {
+  /**
+   * Decodes `BIGINT` as a `number` rather than a `bigint`. Convenient, and
+   * lossy above 2^53, so it is off by default.
+   */
+  readonly bigintAsNumber?: boolean | undefined
+  /**
+   * Decodes `DATETIME` and `TIMESTAMP` as `"YYYY-MM-DD HH:MM:SS"` strings
+   * rather than epoch milliseconds, and `TIME` as `"HH:MM:SS"` rather than a
+   * microsecond duration.
+   */
+  readonly dateStrings?: boolean | undefined
+}
+
+const textDecoder = new TextDecoder("utf-8", { fatal: true })
+
+/** Below this length a per-character loop beats `TextDecoder.decode`. */
+const asciiDecodeLimit = 10
+
+interface MaybeNodeGlobals {
+  readonly Buffer?: { readonly prototype?: { readonly utf8Slice?: (start: number, end: number) => string } }
+}
+
+const utf8Slice: ((this: Uint8Array, start: number, end: number) => string) | undefined =
+  (globalThis as MaybeNodeGlobals).Buffer?.prototype?.utf8Slice
+
+const decodeUtf8 = (bytes: Uint8Array, offset: number, size: number): string => {
+  if (size <= asciiDecodeLimit) {
+    let text = ""
+    let index = 0
+    for (; index < size; index++) {
+      const code = bytes[offset + index]
+      if (code > 0x7f) break
+      text += String.fromCharCode(code)
+    }
+    if (index === size) return text
+  }
+  if (utf8Slice !== undefined) {
+    const text = utf8Slice.call(bytes, offset, offset + size)
+    if (text.indexOf("�") === -1) return text
+  }
+  try {
+    return textDecoder.decode(new Uint8Array(bytes.buffer, bytes.byteOffset + offset, size))
+  } catch {
+    throw new CodecError({ message: "Invalid UTF-8 in a column value" })
+  }
+}
+
+/**
+ * Parses an integer straight from its ASCII digits. Every value of every row
+ * of a text-protocol result goes through a conversion like this one, so it
+ * avoids building the intermediate string that `Number(text)` needs.
+ */
+const asciiInteger = (bytes: Uint8Array, offset: number, size: number): number => {
+  let index = 0
+  let negative = false
+  if (size > 0 && (bytes[offset] === 0x2d || bytes[offset] === 0x2b)) {
+    negative = bytes[offset] === 0x2d
+    index = 1
+  }
+  if (index === size) throw new CodecError({ message: "Empty integer value" })
+  let value = 0
+  for (; index < size; index++) {
+    const digit = bytes[offset + index] - 0x30
+    if (digit < 0 || digit > 9) {
+      // Not a plain integer after all; let the general parser decide.
+      const text = decodeUtf8(bytes, offset, size)
+      const parsed = Number(text)
+      if (Number.isNaN(parsed)) throw new CodecError({ message: `Invalid numeric value "${text}"` })
+      return parsed
+    }
+    value = value * 10 + digit
+  }
+  return negative ? -value : value
+}
+
+const asciiNumber = (bytes: Uint8Array, offset: number, size: number): number => {
+  const text = decodeUtf8(bytes, offset, size)
+  const value = Number(text)
+  if (Number.isNaN(value) && text !== "NaN") {
+    throw new CodecError({ message: `Invalid numeric value "${text}"` })
+  }
+  return value
+}
+
+const asciiBigInt = (bytes: Uint8Array, offset: number, size: number): bigint => {
+  const text = decodeUtf8(bytes, offset, size)
+  try {
+    return BigInt(text)
+  } catch {
+    throw new CodecError({ message: `Invalid integer value "${text}"` })
+  }
+}
+
+/**
+ * Reads a `DATETIME` or `TIMESTAMP` as epoch milliseconds.
+ *
+ * The session runs on UTC — `MysqlConnection` sets `time_zone` on connect — so
+ * the wire text is read as UTC rather than as local time. Sub-millisecond
+ * precision is truncated, matching the `PgTypes` timestamp codec.
+ */
+const parseDateTime = (text: string): number => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,6}))?$/.exec(text)
+  if (match === null) {
+    // MySQL writes the zero date as 0000-00-00 00:00:00 when strict mode is off.
+    if (text.startsWith("0000-00-00")) return Number.NaN
+    throw new CodecError({ message: `Invalid datetime value "${text}"` })
+  }
+  const milliseconds = match[7] === undefined ? 0 : Math.floor(Number(match[7].padEnd(6, "0")) / 1000)
+  return Date.UTC(
+    Number(match[1]),
+    Number(match[2]) - 1,
+    Number(match[3]),
+    Number(match[4]),
+    Number(match[5]),
+    Number(match[6]),
+    milliseconds
+  )
+}
+
+/**
+ * Reads a `TIME` as signed microseconds.
+ *
+ * MySQL's `TIME` is a duration rather than a clock reading: it spans
+ * -838:59:59 to 838:59:59, so it can be negative and its hour field can exceed
+ * 24. Microseconds keep the full precision the type can carry.
+ */
+const parseTime = (text: string): bigint => {
+  const match = /^(-)?(\d{1,3}):(\d{2}):(\d{2})(?:\.(\d{1,6}))?$/.exec(text)
+  if (match === null) throw new CodecError({ message: `Invalid time value "${text}"` })
+  const micros = match[5] === undefined ? BigInt("0") : BigInt(match[5].padEnd(6, "0"))
+  const total = BigInt(match[2]) * BigInt("3600000000") +
+    BigInt(match[3]) * BigInt("60000000") +
+    BigInt(match[4]) * BigInt("1000000") +
+    micros
+  return match[1] === undefined ? total : -total
+}
+
+/** Reads a `BIT` column, which arrives as big-endian bytes in both formats. */
+const parseBits = (bytes: Uint8Array, offset: number, size: number): bigint => {
+  let value = BigInt("0")
+  for (let index = 0; index < size; index++) {
+    value = (value << BigInt("8")) | BigInt(bytes[offset + index])
+  }
+  return value
+}
+
+/** Decodes one column's text-format value. */
+type TextReader = (bytes: Uint8Array, offset: number, size: number) => unknown
+
+/**
+ * Picks a column's reader from its type. A reader may depend on the column's
+ * flags or on the caller's options, so an entry is a function rather than a
+ * reader directly.
+ */
+type TextReaderFor = (column: MysqlProtocol.Column, options: DecodeOptions) => TextReader
+
+/**
+ * How each column type reads in the text protocol.
+ *
+ * Types absent from this table are strings or byte strings, told apart by the
+ * column's collation, which is what `textReaderFor` falls back to.
+ */
+const textReaders: Partial<Record<number, TextReaderFor>> = {
+  [MysqlProtocol.ColumnType.tiny]: () => asciiInteger,
+  [MysqlProtocol.ColumnType.short]: () => asciiInteger,
+  [MysqlProtocol.ColumnType.long]: () => asciiInteger,
+  [MysqlProtocol.ColumnType.int24]: () => asciiInteger,
+  [MysqlProtocol.ColumnType.year]: () => asciiInteger,
+  [MysqlProtocol.ColumnType.longlong]: (_, options) => options.bigintAsNumber === true ? asciiInteger : asciiBigInt,
+  [MysqlProtocol.ColumnType.float]: () => asciiNumber,
+  [MysqlProtocol.ColumnType.double]: () => asciiNumber,
+  // A fixed-point value is never a float: the text on the wire is exact and
+  // parsing it would round.
+  [MysqlProtocol.ColumnType.decimal]: () => decodeUtf8,
+  [MysqlProtocol.ColumnType.newdecimal]: () => decodeUtf8,
+  [MysqlProtocol.ColumnType.date]: () => decodeUtf8,
+  [MysqlProtocol.ColumnType.newdate]: () => decodeUtf8,
+  [MysqlProtocol.ColumnType.datetime]: (_, options) => options.dateStrings === true ? decodeUtf8 : readDateTimeText,
+  [MysqlProtocol.ColumnType.timestamp]: (_, options) => options.dateStrings === true ? decodeUtf8 : readDateTimeText,
+  [MysqlProtocol.ColumnType.time]: (_, options) => options.dateStrings === true ? decodeUtf8 : readTimeText,
+  [MysqlProtocol.ColumnType.json]: () => readJsonText,
+  [MysqlProtocol.ColumnType.bit]: () => parseBits,
+  [MysqlProtocol.ColumnType.geometry]: () => copyBytes,
+  [MysqlProtocol.ColumnType.null]: () => readNull
+}
+
+const readDateTimeText: TextReader = (bytes, offset, size) => parseDateTime(decodeUtf8(bytes, offset, size))
+
+const readTimeText: TextReader = (bytes, offset, size) => parseTime(decodeUtf8(bytes, offset, size))
+
+const readJsonText: TextReader = (bytes, offset, size) => parseJson(decodeUtf8(bytes, offset, size))
+
+const readNull: TextReader = () => null
+
+const parseJson = (text: string): unknown => {
+  try {
+    return JSON.parse(text)
+  } catch {
+    throw new CodecError({ message: "Invalid JSON in a column value" })
+  }
+}
+
+/** Chooses the reader for a column, from its type, flags and collation. */
+const textReaderFor = (column: MysqlProtocol.Column, options: DecodeOptions = {}): TextReader => {
+  const reader = textReaders[column.type]
+  if (reader !== undefined) return reader(column, options)
+  return MysqlProtocol.Column.isBinary(column) ? copyBytes : decodeUtf8
+}
+
+const copyBytes = (bytes: Uint8Array, offset: number, size: number): Uint8Array => bytes.slice(offset, offset + size)
+
+/**
+ * Builds the field reader for a text-protocol result set.
+ *
+ * **Details**
+ *
+ * The per-column readers are resolved once for the whole result rather than
+ * per row, which is what makes decoding a row a switch-free walk.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const makeTextFieldReader = (
+  columns: ReadonlyArray<MysqlProtocol.Column>,
+  options: DecodeOptions = {}
+): MysqlProtocol.FieldReader<unknown> => {
+  const readers = columns.map((column) => textReaderFor(column, options))
+  return (bytes, offset, size, column) => size === -1 ? null : readers[column](bytes, offset, size)
+}
+
+// -----------------------------------------------------------------------------
+// binary protocol
+// -----------------------------------------------------------------------------
+
+/**
+ * Reads a length-encoded length and returns it with the offset just past it.
+ * A binary field is never SQL NULL - the row's bitmap says that instead - so
+ * the NULL marker is malformed here.
+ */
+const readLength = (bytes: Uint8Array, offset: number, limit: number): readonly [length: number, next: number] => {
+  if (offset >= limit) throw new CodecError({ message: "Truncated binary value" })
+  const first = bytes[offset]
+  if (first < 0xfb) return [first, offset + 1]
+  if (first === 0xfc) return [bytes[offset + 1] | (bytes[offset + 2] << 8), offset + 3]
+  if (first === 0xfd) {
+    return [bytes[offset + 1] | (bytes[offset + 2] << 8) | (bytes[offset + 3] << 16), offset + 4]
+  }
+  if (first === 0xfe) {
+    const view = new DataView(bytes.buffer, bytes.byteOffset + offset + 1, 8)
+    const value = view.getBigUint64(0, true)
+    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+      throw new CodecError({ message: `Binary value length ${value} exceeds the safe integer range` })
+    }
+    return [Number(value), offset + 9]
+  }
+  throw new CodecError({ message: `Invalid length prefix 0x${first.toString(16)} in a binary value` })
+}
+
+let cachedBytes: Uint8Array | undefined
+let cachedView: DataView | undefined
+
+/**
+ * A `DataView` over a row's payload.
+ *
+ * Allocating one per field read made this the largest frame in the module's
+ * profile, ahead of the string decoder. Every column of a row is read from
+ * the same payload, so caching the last one turns those allocations into a
+ * single identity check. The view still spans exactly the payload, because
+ * its bounds are what turns a truncated field into a thrown error rather
+ * than a silent read into the next row.
+ */
+const viewOf = (bytes: Uint8Array): DataView => {
+  if (bytes !== cachedBytes) {
+    cachedBytes = bytes
+    cachedView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  }
+  return cachedView!
+}
+
+/**
+ * Builds an epoch-millisecond timestamp from the components a binary temporal
+ * value carries. The session runs on UTC, so the components are read as UTC.
+ */
+const dateFromParts = (
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  micros: number
+): number => Date.UTC(year, month - 1, day, hour, minute, second, Math.floor(micros / 1000))
+
+const pad = (value: number, width: number): string => String(value).padStart(width, "0")
+
+/**
+ * Reads one column's binary-format value, returning it with the offset just
+ * past it.
+ */
+type BinaryReader = (
+  bytes: Uint8Array,
+  offset: number,
+  limit: number
+) => readonly [value: unknown, next: number]
+
+const readLenencBytes = (
+  bytes: Uint8Array,
+  offset: number,
+  limit: number
+): readonly [Uint8Array, number] => {
+  const [length, start] = readLength(bytes, offset, limit)
+  if (start + length > limit) throw new CodecError({ message: "Truncated binary string" })
+  return [bytes.slice(start, start + length), start + length]
+}
+
+const readLenencText = (
+  bytes: Uint8Array,
+  offset: number,
+  limit: number
+): readonly [string, number] => {
+  const [length, start] = readLength(bytes, offset, limit)
+  if (start + length > limit) throw new CodecError({ message: "Truncated binary string" })
+  return [decodeUtf8(bytes, start, length), start + length]
+}
+
+/**
+ * Reads a binary `DATE`, `DATETIME` or `TIMESTAMP`, which carries no
+ * components beyond the precision it needs: four bytes for a date, seven with
+ * a time, eleven with microseconds, and zero for the all-zero value.
+ */
+const readTemporal = (
+  bytes: Uint8Array,
+  offset: number,
+  limit: number
+): readonly [
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  micros: number,
+  next: number
+] => {
+  const [length, start] = readLength(bytes, offset, limit)
+  if (start + length > limit) throw new CodecError({ message: "Truncated binary temporal value" })
+  if (length === 0) return [0, 0, 0, 0, 0, 0, 0, start]
+  const view = viewOf(bytes)
+  const year = view.getUint16(start, true)
+  const month = bytes[start + 2]
+  const day = bytes[start + 3]
+  if (length === 4) return [year, month, day, 0, 0, 0, 0, start + 4]
+  const hour = bytes[start + 4]
+  const minute = bytes[start + 5]
+  const second = bytes[start + 6]
+  if (length === 7) return [year, month, day, hour, minute, second, 0, start + 7]
+  if (length !== 11) throw new CodecError({ message: `Invalid binary temporal length ${length}` })
+  const micros = view.getUint32(start + 7, true)
+  return [year, month, day, hour, minute, second, micros, start + 11]
+}
+
+/**
+ * Reads a binary `TIME`, which is a signed duration carrying whole days
+ * separately from the hour field.
+ */
+const readDuration = (bytes: Uint8Array, offset: number, limit: number): readonly [bigint, number] => {
+  const [length, start] = readLength(bytes, offset, limit)
+  if (start + length > limit) throw new CodecError({ message: "Truncated binary time value" })
+  if (length === 0) return [BigInt("0"), start]
+  if (length !== 8 && length !== 12) {
+    throw new CodecError({ message: `Invalid binary time length ${length}` })
+  }
+  const view = viewOf(bytes)
+  const negative = bytes[start] === 1
+  const days = view.getUint32(start + 1, true)
+  const hours = bytes[start + 5]
+  const minutes = bytes[start + 6]
+  const seconds = bytes[start + 7]
+  const micros = length === 12 ? view.getUint32(start + 8, true) : 0
+  const total = BigInt(days) * BigInt("86400000000") +
+    BigInt(hours) * BigInt("3600000000") +
+    BigInt(minutes) * BigInt("60000000") +
+    BigInt(seconds) * BigInt("1000000") +
+    BigInt(micros)
+  return [negative ? -total : total, start + length]
+}
+
+const readInt8: BinaryReader = (bytes, offset) => [viewOf(bytes).getInt8(offset), offset + 1]
+const readUint8: BinaryReader = (bytes, offset) => [bytes[offset], offset + 1]
+const readInt16: BinaryReader = (bytes, offset) => [viewOf(bytes).getInt16(offset, true), offset + 2]
+const readUint16: BinaryReader = (bytes, offset) => [viewOf(bytes).getUint16(offset, true), offset + 2]
+const readInt32: BinaryReader = (bytes, offset) => [viewOf(bytes).getInt32(offset, true), offset + 4]
+const readUint32: BinaryReader = (bytes, offset) => [viewOf(bytes).getUint32(offset, true), offset + 4]
+const readFloat32: BinaryReader = (bytes, offset) => [viewOf(bytes).getFloat32(offset, true), offset + 4]
+const readFloat64: BinaryReader = (bytes, offset) => [viewOf(bytes).getFloat64(offset, true), offset + 8]
+const readNullBinary: BinaryReader = (_, offset) => [null, offset]
+
+const readBigInt = (unsigned: boolean, asNumber: boolean): BinaryReader => (bytes, offset) => {
+  const view = viewOf(bytes)
+  const value = unsigned ? view.getBigUint64(offset, true) : view.getBigInt64(offset, true)
+  return [asNumber ? Number(value) : value, offset + 8]
+}
+
+const readDateBinary: BinaryReader = (bytes, offset, limit) => {
+  const [year, month, day, , , , , next] = readTemporal(bytes, offset, limit)
+  return [`${pad(year, 4)}-${pad(month, 2)}-${pad(day, 2)}`, next]
+}
+
+const readDateTimeBinary: BinaryReader = (bytes, offset, limit) => {
+  const [year, month, day, hour, minute, second, micros, next] = readTemporal(bytes, offset, limit)
+  return [dateFromParts(year, month, day, hour, minute, second, micros), next]
+}
+
+/**
+ * Renders the fractional-seconds suffix a column's declared precision calls
+ * for. The binary protocol omits the microseconds field when the value has
+ * none, so the precision has to come from the column rather than the row, or
+ * a `DATETIME(6)` holding a whole second would render differently from the
+ * same value read over the text protocol.
+ */
+const fraction = (micros: number, decimals: number): string =>
+  decimals > 0 ? `.${pad(micros, 6).slice(0, decimals)}` : ""
+
+const readDateTimeBinaryString = (decimals: number): BinaryReader => (bytes, offset, limit) => {
+  const [year, month, day, hour, minute, second, micros, next] = readTemporal(bytes, offset, limit)
+  return [
+    `${pad(year, 4)}-${pad(month, 2)}-${pad(day, 2)} ${pad(hour, 2)}:${pad(minute, 2)}:${pad(second, 2)}${
+      fraction(micros, decimals)
+    }`,
+    next
+  ]
+}
+
+const readTimeBinary: BinaryReader = (bytes, offset, limit) => readDuration(bytes, offset, limit)
+
+const readTimeBinaryString = (decimals: number): BinaryReader => (bytes, offset, limit) => {
+  const [micros, next] = readDuration(bytes, offset, limit)
+  const absolute = micros < BigInt("0") ? -micros : micros
+  const hours = absolute / BigInt("3600000000")
+  const minutes = (absolute / BigInt("60000000")) % BigInt("60")
+  const seconds = (absolute / BigInt("1000000")) % BigInt("60")
+  const sign = micros < BigInt("0") ? "-" : ""
+  return [
+    `${sign}${pad(Number(hours), 2)}:${pad(Number(minutes), 2)}:${pad(Number(seconds), 2)}${
+      fraction(Number(absolute % BigInt("1000000")), decimals)
+    }`,
+    next
+  ]
+}
+
+const readJsonBinary: BinaryReader = (bytes, offset, limit) => {
+  const [text, next] = readLenencText(bytes, offset, limit)
+  return [parseJson(text), next]
+}
+
+const readBitsBinary: BinaryReader = (bytes, offset, limit) => {
+  const [value, next] = readLenencBytes(bytes, offset, limit)
+  return [parseBits(value, 0, value.length), next]
+}
+
+/** Picks a column's binary reader from its type. */
+type BinaryReaderFor = (column: MysqlProtocol.Column, options: DecodeOptions) => BinaryReader
+
+/**
+ * How each column type reads in the binary protocol.
+ *
+ * Types absent from this table are length-encoded strings or byte strings,
+ * told apart by the column's collation.
+ */
+const binaryReaders: Partial<Record<number, BinaryReaderFor>> = {
+  [MysqlProtocol.ColumnType.tiny]: (column) => MysqlProtocol.Column.isUnsigned(column) ? readUint8 : readInt8,
+  [MysqlProtocol.ColumnType.short]: (column) => MysqlProtocol.Column.isUnsigned(column) ? readUint16 : readInt16,
+  [MysqlProtocol.ColumnType.year]: (column) => MysqlProtocol.Column.isUnsigned(column) ? readUint16 : readInt16,
+  [MysqlProtocol.ColumnType.long]: (column) => MysqlProtocol.Column.isUnsigned(column) ? readUint32 : readInt32,
+  [MysqlProtocol.ColumnType.int24]: (column) => MysqlProtocol.Column.isUnsigned(column) ? readUint32 : readInt32,
+  [MysqlProtocol.ColumnType.longlong]: (column, options) =>
+    readBigInt(MysqlProtocol.Column.isUnsigned(column), options.bigintAsNumber === true),
+  [MysqlProtocol.ColumnType.float]: () => readFloat32,
+  [MysqlProtocol.ColumnType.double]: () => readFloat64,
+  [MysqlProtocol.ColumnType.decimal]: () => readLenencText,
+  [MysqlProtocol.ColumnType.newdecimal]: () => readLenencText,
+  [MysqlProtocol.ColumnType.date]: () => readDateBinary,
+  [MysqlProtocol.ColumnType.newdate]: () => readDateBinary,
+  [MysqlProtocol.ColumnType.datetime]: (column, options) =>
+    options.dateStrings === true ? readDateTimeBinaryString(column.decimals) : readDateTimeBinary,
+  [MysqlProtocol.ColumnType.timestamp]: (column, options) =>
+    options.dateStrings === true ? readDateTimeBinaryString(column.decimals) : readDateTimeBinary,
+  [MysqlProtocol.ColumnType.time]: (column, options) =>
+    options.dateStrings === true ? readTimeBinaryString(column.decimals) : readTimeBinary,
+  [MysqlProtocol.ColumnType.json]: () => readJsonBinary,
+  [MysqlProtocol.ColumnType.bit]: () => readBitsBinary,
+  [MysqlProtocol.ColumnType.geometry]: () => readLenencBytes,
+  [MysqlProtocol.ColumnType.null]: () => readNullBinary
+}
+
+/** Chooses the binary reader for a column, from its type, flags and collation. */
+const binaryReaderFor = (column: MysqlProtocol.Column, options: DecodeOptions = {}): BinaryReader => {
+  const reader = binaryReaders[column.type]
+  if (reader !== undefined) return reader(column, options)
+  return MysqlProtocol.Column.isBinary(column) ? readLenencBytes : readLenencText
+}
+
+/**
+ * Builds the field reader for a binary-protocol result set.
+ *
+ * @category decoding
+ * @since 4.0.0
+ */
+export const makeBinaryFieldReader = (
+  columns: ReadonlyArray<MysqlProtocol.Column>,
+  options: DecodeOptions = {}
+): MysqlProtocol.BinaryFieldReader<unknown> => {
+  const readers = columns.map((column) => binaryReaderFor(column, options))
+  return (bytes, offset, limit, column) => readers[column](bytes, offset, limit)
+}
+
+// -----------------------------------------------------------------------------
+// parameters
+// -----------------------------------------------------------------------------
+
+const sqlNullParameter: MysqlProtocol.BoundParameter = {
+  type: MysqlProtocol.ColumnType.null,
+  unsigned: false,
+  write: undefined
+}
+
+const INT32_MIN = -2147483648
+const INT32_MAX = 2147483647
+const INT64_MAX = BigInt("2") ** BigInt("63") - BigInt("1")
+
+/**
+ * Binds one JavaScript value as a prepared-statement parameter, choosing the
+ * wire type from the value.
+ *
+ * **Details**
+ *
+ * Unlike the text protocol, nothing here is written into the statement, so a
+ * value cannot change how the statement parses.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const bindParameter = (value: unknown): MysqlProtocol.BoundParameter => {
+  if (value === null || value === undefined) return sqlNullParameter
+  switch (typeof value) {
+    case "boolean":
+      return {
+        type: MysqlProtocol.ColumnType.tiny,
+        unsigned: false,
+        write: (sink) => sink.uint8(value ? 1 : 0)
+      }
+    case "number": {
+      if (!Number.isFinite(value)) {
+        throw new CodecError({ message: `Cannot bind the non-finite number ${value}` })
+      }
+      if (!Number.isInteger(value)) {
+        return {
+          type: MysqlProtocol.ColumnType.double,
+          unsigned: false,
+          write: (sink) => sink.float64(value)
+        }
+      }
+      if (value >= INT32_MIN && value <= INT32_MAX) {
+        return {
+          type: MysqlProtocol.ColumnType.long,
+          unsigned: false,
+          write: (sink) => sink.uint32(value >>> 0)
+        }
+      }
+      return {
+        type: MysqlProtocol.ColumnType.longlong,
+        unsigned: false,
+        write: (sink) => sink.int64(BigInt(value))
+      }
+    }
+    case "bigint": {
+      const unsigned = value > INT64_MAX
+      return {
+        type: MysqlProtocol.ColumnType.longlong,
+        unsigned,
+        write: (sink) => unsigned ? sink.uint64(value) : sink.int64(value)
+      }
+    }
+    case "string":
+      return {
+        type: MysqlProtocol.ColumnType.varString,
+        unsigned: false,
+        write: (sink) => sink.lenencString(value)
+      }
+    case "object":
+      break
+    default:
+      throw new CodecError({ message: `Cannot bind a value of type ${typeof value}` })
+  }
+  if (value instanceof Date) {
+    const time = value.getTime()
+    if (Number.isNaN(time)) throw new CodecError({ message: "Cannot bind an invalid Date" })
+    return {
+      type: MysqlProtocol.ColumnType.datetime,
+      unsigned: false,
+      write: (sink) => {
+        sink.uint8(11)
+        sink.uint16(value.getUTCFullYear())
+        sink.uint8(value.getUTCMonth() + 1)
+        sink.uint8(value.getUTCDate())
+        sink.uint8(value.getUTCHours())
+        sink.uint8(value.getUTCMinutes())
+        sink.uint8(value.getUTCSeconds())
+        sink.uint32(value.getUTCMilliseconds() * 1000)
+      }
+    }
+  }
+  if (value instanceof Uint8Array) {
+    return {
+      type: MysqlProtocol.ColumnType.blob,
+      unsigned: false,
+      write: (sink) => sink.lenencBytes(value)
+    }
+  }
+  if (value instanceof Int8Array) {
+    const bytes = new Uint8Array(value.buffer, value.byteOffset, value.length)
+    return {
+      type: MysqlProtocol.ColumnType.blob,
+      unsigned: false,
+      write: (sink) => sink.lenencBytes(bytes)
+    }
+  }
+  // Anything else is stored as JSON, matching how a JSON column round-trips.
+  const json = JSON.stringify(value)
+  return {
+    type: MysqlProtocol.ColumnType.varString,
+    unsigned: false,
+    write: (sink) => sink.lenencString(json)
+  }
+}
+
+/**
+ * Binds a statement's parameters, reporting a value it cannot represent rather
+ * than throwing.
+ *
+ * @category encoding
+ * @since 4.0.0
+ */
+export const bindParameters = (
+  params: ReadonlyArray<unknown>
+): Result.Result<Array<MysqlProtocol.BoundParameter>, CodecError> => {
+  try {
+    return Result.succeed(params.map(bindParameter))
+  } catch (error) {
+    if (error instanceof CodecError) return Result.fail(error)
+    throw error
+  }
+}

--- a/packages/sql/mysql/src/index.ts
+++ b/packages/sql/mysql/src/index.ts
@@ -1,0 +1,40 @@
+/**
+ * @since 4.0.0
+ */
+
+// @barrel: Auto-generated exports. Do not edit manually.
+
+/**
+ * @since 4.0.0
+ */
+export * as MysqlAuth from "./MysqlAuth.ts"
+
+/**
+ * @since 4.0.0
+ */
+export * as MysqlClient from "./MysqlClient.ts"
+
+/**
+ * @since 4.0.0
+ */
+export * as MysqlConnection from "./MysqlConnection.ts"
+
+/**
+ * @since 4.0.0
+ */
+export * as MysqlMigrator from "./MysqlMigrator.ts"
+
+/**
+ * @since 4.0.0
+ */
+export * as MysqlPool from "./MysqlPool.ts"
+
+/**
+ * @since 4.0.0
+ */
+export * as MysqlProtocol from "./MysqlProtocol.ts"
+
+/**
+ * @since 4.0.0
+ */
+export * as MysqlTypes from "./MysqlTypes.ts"

--- a/packages/sql/mysql/src/internal/buffer.ts
+++ b/packages/sql/mysql/src/internal/buffer.ts
@@ -1,0 +1,432 @@
+/**
+ * Reading and writing the bytes a MySQL packet is made of.
+ *
+ * This is buffer machinery rather than protocol: framing, message shapes and
+ * command semantics all live in `MysqlProtocol`. Both the reader and the
+ * writer are deliberately imperative and reused across packets, because they
+ * run once per column of every row.
+ *
+ * @internal
+ */
+import * as Data from "effect/Data"
+
+/**
+ * Bytes that ran out, or a value that will not fit.
+ *
+ * The buffer does not know whether it is being read or written on behalf of a
+ * decode or an encode, so `MysqlProtocol` decides which of its two public
+ * errors this becomes at the boundary.
+ *
+ * @internal
+ */
+export class BufferError extends Data.TaggedError("MysqlBufferError")<{
+  readonly message: string
+}> {}
+
+export const textEncoder = new TextEncoder()
+export const textDecoder = new TextDecoder("utf-8", { fatal: true })
+
+/**
+ * Above this length `TextEncoder.encodeInto` beats a per-character loop, below
+ * it the call overhead dominates.
+ */
+export const asciiEncodeLimit = 48
+
+/** Below this length a per-character loop beats `TextDecoder.decode`. */
+export const asciiDecodeLimit = 10
+
+/** Up to this many bytes a copy loop beats `Uint8Array.prototype.set`. */
+export const smallCopyLimit = 8
+
+/**
+ * A view over part of a cached backing store. Slicing runs once per column of
+ * every row, and both obvious spellings are slower than this one: `subarray`
+ * consults the constructor's `Symbol.species` before it can allocate, and
+ * reading `.buffer` off a typed array is an accessor call rather than a field
+ * load.
+ */
+export const view = (store: ArrayBufferLike, offset: number, length: number): Uint8Array =>
+  new Uint8Array(store, offset, length)
+
+/**
+ * Node's own UTF-8 decoder, which is faster than `TextDecoder` for short runs.
+ * A result containing a replacement character goes to the strict decoder, so
+ * invalid bytes still fail exactly as they did.
+ */
+export interface MaybeNodeGlobals {
+  readonly Buffer?: { readonly prototype?: { readonly utf8Slice?: (start: number, end: number) => string } }
+}
+
+export const utf8Slice: ((this: Uint8Array, start: number, end: number) => string) | undefined =
+  (globalThis as MaybeNodeGlobals).Buffer?.prototype?.utf8Slice
+
+export const decodeUtf8 = (bytes: Uint8Array, offset: number, size: number): string => {
+  if (size <= asciiDecodeLimit) {
+    let text = ""
+    let index = 0
+    for (; index < size; index++) {
+      const code = bytes[offset + index]
+      if (code > 0x7f) break
+      text += String.fromCharCode(code)
+    }
+    if (index === size) return text
+  }
+  if (utf8Slice !== undefined) {
+    const text = utf8Slice.call(bytes, offset, offset + size)
+    if (text.indexOf("�") === -1) return text
+  }
+  try {
+    return textDecoder.decode(view(bytes.buffer, bytes.byteOffset + offset, size))
+  } catch {
+    throw new BufferError({ message: "Invalid UTF-8 in packet" })
+  }
+}
+
+export const emptyBytes = new Uint8Array(0)
+
+/**
+ * A cursor over a packet payload. Integers are little-endian, which is the
+ * opposite of the PostgreSQL protocol.
+ */
+export class Reader {
+  bytes: Uint8Array = emptyBytes
+  store: ArrayBufferLike = emptyBytes.buffer
+  base = 0
+  offset = 0
+  limit = 0
+
+  reset(bytes: Uint8Array, offset: number, limit: number): void {
+    this.bytes = bytes
+    this.store = bytes.buffer
+    this.base = bytes.byteOffset
+    this.offset = offset
+    this.limit = limit
+  }
+
+  require(size: number): void {
+    if (size < 0) {
+      throw new BufferError({ message: `Invalid read of ${size} byte(s)` })
+    }
+    if (this.offset + size > this.limit) {
+      throw new BufferError({ message: `Truncated packet: expected ${size} more byte(s)` })
+    }
+  }
+
+  uint8(): number {
+    this.require(1)
+    return this.bytes[this.offset++]
+  }
+
+  uint16(): number {
+    this.require(2)
+    const bytes = this.bytes
+    const offset = this.offset
+    this.offset = offset + 2
+    return bytes[offset] | (bytes[offset + 1] << 8)
+  }
+
+  uint24(): number {
+    this.require(3)
+    const bytes = this.bytes
+    const offset = this.offset
+    this.offset = offset + 3
+    return bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16)
+  }
+
+  uint32(): number {
+    this.require(4)
+    const bytes = this.bytes
+    const offset = this.offset
+    this.offset = offset + 4
+    return (bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16) | (bytes[offset + 3] << 24)) >>> 0
+  }
+
+  uint64(): bigint {
+    this.require(8)
+    const bytes = this.bytes
+    const offset = this.offset
+    this.offset = offset + 8
+    const low = BigInt(
+      (bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16) | (bytes[offset + 3] << 24)) >>> 0
+    )
+    const high = BigInt(
+      (bytes[offset + 4] | (bytes[offset + 5] << 8) | (bytes[offset + 6] << 16) | (bytes[offset + 7] << 24)) >>> 0
+    )
+    return (high << BigInt("32")) | low
+  }
+
+  /**
+   * Reads a length-encoded integer. Returns `null` for the `0xfb` marker, which
+   * means SQL NULL where a value was expected and is invalid elsewhere.
+   *
+   * Values above `Number.MAX_SAFE_INTEGER` come back as `bigint`; everything
+   * else is a `number`, so callers that use the result as a length can narrow
+   * with `lengthOf`.
+   */
+  lenencInt(): number | bigint | null {
+    const first = this.uint8()
+    if (first < 0xfb) return first
+    if (first === 0xfb) return null
+    if (first === 0xfc) return this.uint16()
+    if (first === 0xfd) return this.uint24()
+    if (first === 0xfe) {
+      const value = this.uint64()
+      return value <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(value) : value
+    }
+    throw new BufferError({ message: `Invalid length-encoded integer prefix 0x${first.toString(16)}` })
+  }
+
+  raw(size: number): Uint8Array {
+    this.require(size)
+    const value = view(this.store, this.base + this.offset, size)
+    this.offset += size
+    return value
+  }
+
+  rest(): Uint8Array {
+    return this.raw(this.limit - this.offset)
+  }
+
+  skip(size: number): void {
+    this.require(size)
+    this.offset += size
+  }
+
+  string(size: number): string {
+    this.require(size)
+    const value = decodeUtf8(this.bytes, this.offset, size)
+    this.offset += size
+    return value
+  }
+
+  restString(): string {
+    return this.string(this.limit - this.offset)
+  }
+
+  /** A length-encoded string, or `null` for the `0xfb` marker. */
+  lenencString(): string | null {
+    const size = this.lenencInt()
+    if (size === null) return null
+    return this.string(lengthOf(size))
+  }
+
+  cString(): string {
+    const end = this.bytes.indexOf(0, this.offset)
+    if (end === -1 || end >= this.limit) {
+      throw new BufferError({ message: "Unterminated string" })
+    }
+    const value = decodeUtf8(this.bytes, this.offset, end - this.offset)
+    this.offset = end + 1
+    return value
+  }
+}
+
+export const lengthOf = (value: number | bigint): number => {
+  if (typeof value === "number") return value
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new BufferError({ message: `Length ${value} exceeds the safe integer range` })
+  }
+  return Number(value)
+}
+
+/**
+ * Writes packets back to back into a pooled buffer and hands out a view of each
+ * one, so encoding costs no allocation of its own. Bytes below `start` have
+ * already been handed out and are never rewritten; when the pool runs out it is
+ * replaced rather than reused.
+ */
+export class Writer {
+  readonly poolSize: number
+  bytes: Uint8Array
+  view: DataView
+  start = 0
+  offset = 0
+
+  constructor(poolSize: number) {
+    this.poolSize = poolSize
+    this.bytes = new Uint8Array(poolSize)
+    this.view = new DataView(this.bytes.buffer)
+  }
+
+  reserve(size: number): void {
+    if (this.offset + size <= this.bytes.length) return
+    const pending = this.offset - this.start
+    let capacity = this.poolSize
+    while (capacity < pending + size) capacity *= 2
+    const next = new Uint8Array(capacity)
+    next.set(this.bytes.subarray(this.start, this.offset))
+    this.bytes = next
+    this.view = new DataView(next.buffer)
+    this.start = 0
+    this.offset = pending
+  }
+
+  /** Starts a packet, dropping anything a failed write left behind. */
+  begin(): void {
+    this.start = this.offset
+  }
+
+  uint8(value: number): void {
+    this.reserve(1)
+    this.bytes[this.offset++] = value
+  }
+
+  uint16(value: number): void {
+    this.reserve(2)
+    const bytes = this.bytes
+    const offset = this.offset
+    bytes[offset] = value
+    bytes[offset + 1] = value >>> 8
+    this.offset = offset + 2
+  }
+
+  uint24(value: number): void {
+    this.reserve(3)
+    this.setUint24(this.offset, value)
+    this.offset += 3
+  }
+
+  setUint24(offset: number, value: number): void {
+    const bytes = this.bytes
+    bytes[offset] = value
+    bytes[offset + 1] = value >>> 8
+    bytes[offset + 2] = value >>> 16
+  }
+
+  uint32(value: number): void {
+    this.reserve(4)
+    const bytes = this.bytes
+    const offset = this.offset
+    bytes[offset] = value
+    bytes[offset + 1] = value >>> 8
+    bytes[offset + 2] = value >>> 16
+    bytes[offset + 3] = value >>> 24
+    this.offset = offset + 4
+  }
+
+  uint64(value: bigint): void {
+    this.reserve(8)
+    this.view.setBigUint64(this.offset, value, true)
+    this.offset += 8
+  }
+
+  int64(value: bigint): void {
+    this.reserve(8)
+    this.view.setBigInt64(this.offset, value, true)
+    this.offset += 8
+  }
+
+  float32(value: number): void {
+    this.reserve(4)
+    this.view.setFloat32(this.offset, value, true)
+    this.offset += 4
+  }
+
+  float64(value: number): void {
+    this.reserve(8)
+    this.view.setFloat64(this.offset, value, true)
+    this.offset += 8
+  }
+
+  lenencInt(value: number | bigint): void {
+    if (typeof value === "bigint") {
+      if (value < BigInt("0")) throw new BufferError({ message: `Negative length-encoded integer ${value}` })
+      if (value < BigInt("251")) {
+        this.uint8(Number(value))
+        return
+      }
+      this.uint8(0xfe)
+      this.uint64(value)
+      return
+    }
+    if (value < 0 || !Number.isInteger(value)) {
+      throw new BufferError({ message: `Invalid length-encoded integer ${value}` })
+    }
+    if (value < 251) this.uint8(value)
+    else if (value < 0x10000) {
+      this.uint8(0xfc)
+      this.uint16(value)
+    } else if (value < 0x1000000) {
+      this.uint8(0xfd)
+      this.uint24(value)
+    } else {
+      this.uint8(0xfe)
+      this.uint64(BigInt(value))
+    }
+  }
+
+  raw(value: Uint8Array): void {
+    const length = value.length
+    this.reserve(length)
+    const bytes = this.bytes
+    const offset = this.offset
+    if (length <= smallCopyLimit) {
+      for (let index = 0; index < length; index++) bytes[offset + index] = value[index]
+    } else {
+      bytes.set(value, offset)
+    }
+    this.offset = offset + length
+  }
+
+  fill(byte: number, count: number): void {
+    this.reserve(count)
+    this.bytes.fill(byte, this.offset, this.offset + count)
+    this.offset += count
+  }
+
+  utf8(value: string, nul = false): void {
+    const length = value.length
+    if (length <= asciiEncodeLimit) {
+      this.reserve(length + (nul ? 1 : 0))
+      const bytes = this.bytes
+      const start = this.offset
+      let i = 0
+      for (; i < length; i++) {
+        const code = value.charCodeAt(i)
+        if (code > 0x7f) break
+        bytes[start + i] = code
+      }
+      if (i === length) {
+        const offset = start + length
+        if (nul) bytes[offset] = 0
+        this.offset = offset + (nul ? 1 : 0)
+        return
+      }
+    }
+    // UTF-8 takes at most three bytes per UTF-16 code unit, and four for the
+    // two units of a surrogate pair, so this covers any string.
+    this.reserve(length * 3 + (nul ? 1 : 0))
+    this.offset += textEncoder.encodeInto(value, this.bytes.subarray(this.offset)).written
+    if (nul) this.bytes[this.offset++] = 0
+  }
+
+  cString(value: string): void {
+    this.utf8(value, true)
+  }
+
+  lenencString(value: string): void {
+    // Measure first: the length prefix is variable-width, so it cannot be
+    // backfilled the way a fixed-width one could.
+    const encoded = textEncoder.encode(value)
+    this.lenencInt(encoded.length)
+    this.raw(encoded)
+  }
+
+  lenencBytes(value: Uint8Array): void {
+    this.lenencInt(value.length)
+    this.raw(value)
+  }
+
+  finish(): Uint8Array {
+    const value = view(this.bytes.buffer, this.bytes.byteOffset + this.start, this.offset - this.start)
+    if (this.bytes.length > this.poolSize) {
+      this.bytes = new Uint8Array(this.poolSize)
+      this.view = new DataView(this.bytes.buffer)
+      this.start = 0
+      this.offset = 0
+    } else {
+      this.start = this.offset
+    }
+    return value
+  }
+}

--- a/packages/sql/mysql/src/internal/config.ts
+++ b/packages/sql/mysql/src/internal/config.ts
@@ -1,0 +1,101 @@
+import * as Redacted from "effect/Redacted"
+import * as EffectResult from "effect/Result"
+import { ConnectionError, SqlError } from "effect/unstable/sql/SqlError"
+
+/**
+ * Connection settings recovered from a URL. Shared by `MysqlConnection`, which
+ * opens the socket, and `MysqlClient`, which reports the address on its spans.
+ *
+ * @internal
+ */
+export interface UrlConfig {
+  host?: string | undefined
+  port?: number | undefined
+  database?: string | undefined
+  username?: string | undefined
+  password?: string | undefined
+  ssl?: boolean | undefined
+}
+
+/** @internal */
+export const configError = (message: string, cause?: unknown): SqlError =>
+  new SqlError({
+    reason: new ConnectionError({
+      cause: cause ?? new Error(message),
+      message: `MysqlConnection: ${message}`,
+      operation: "connect"
+    })
+  })
+
+/** @internal */
+export const parseUrl = (raw: string): EffectResult.Result<UrlConfig, SqlError> => {
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch (cause) {
+    return EffectResult.fail(configError("Invalid connection URL", cause))
+  }
+  if (url.protocol !== "mysql:" && url.protocol !== "mysqls:") {
+    return EffectResult.fail(configError(`Unsupported URL protocol "${url.protocol}"`))
+  }
+  const config: UrlConfig = {}
+  const mutable = config as Record<string, unknown>
+  if (url.hostname !== "") {
+    // A bracketed IPv6 literal keeps its brackets in `hostname`.
+    mutable.host = decodeURIComponent(
+      url.hostname.startsWith("[") && url.hostname.endsWith("]")
+        ? url.hostname.slice(1, -1)
+        : url.hostname
+    )
+  }
+  if (url.port !== "") mutable.port = Number(url.port)
+  if (url.username !== "") mutable.username = decodeURIComponent(url.username)
+  if (url.password !== "") mutable.password = decodeURIComponent(url.password)
+  const database = url.pathname.replace(/^\//, "")
+  if (database !== "") mutable.database = decodeURIComponent(database)
+  if (url.protocol === "mysqls:") mutable.ssl = true
+  const ssl = url.searchParams.get("ssl")
+  if (ssl !== null) mutable.ssl = ssl !== "false" && ssl !== "0"
+  return EffectResult.succeed(config)
+}
+
+/**
+ * Where a client is pointed, once explicit settings and a connection URL have
+ * been reconciled. Reporting an address should not depend on which of the two
+ * the caller used.
+ *
+ * @internal
+ */
+export interface Address {
+  readonly host: string
+  readonly port: number
+  readonly username: string | undefined
+  readonly password: string | undefined
+  readonly database: string | undefined
+}
+
+/** @internal */
+export interface AddressSource {
+  readonly url?: Redacted.Redacted | undefined
+  readonly host?: string | undefined
+  readonly port?: number | undefined
+  readonly username?: string | undefined
+  readonly password?: Redacted.Redacted | undefined
+  readonly database?: string | undefined
+}
+
+/** @internal */
+export const resolveAddress = (config: AddressSource): Address => {
+  let url: UrlConfig | undefined
+  if (config.url !== undefined) {
+    const parsed = parseUrl(Redacted.value(config.url))
+    if (EffectResult.isSuccess(parsed)) url = parsed.success
+  }
+  return {
+    host: config.host ?? url?.host ?? "localhost",
+    port: config.port ?? url?.port ?? 3306,
+    username: config.username ?? url?.username,
+    password: config.password !== undefined ? Redacted.value(config.password) : url?.password,
+    database: config.database ?? url?.database
+  }
+}

--- a/packages/sql/mysql/src/internal/connection.ts
+++ b/packages/sql/mysql/src/internal/connection.ts
@@ -1,0 +1,13 @@
+/** @internal */
+export const internalsKey = "~@effect/sql-mysql/MysqlConnection/internals" as const
+
+/** @internal */
+export interface ConnectionInternals {
+  readonly isDead: () => boolean
+  /** Fired once when the connection dies outside its own scope release. */
+  readonly fatalHooks: Set<() => void>
+}
+
+/** @internal */
+export const connectionInternals = (connection: object): ConnectionInternals =>
+  (connection as Record<typeof internalsKey, ConnectionInternals>)[internalsKey]

--- a/packages/sql/mysql/src/internal/escape.ts
+++ b/packages/sql/mysql/src/internal/escape.ts
@@ -1,0 +1,193 @@
+import { CodecError } from "../MysqlTypes.ts"
+
+/**
+ * MySQL's text protocol has no placeholders: `COM_QUERY` carries one finished
+ * statement. A statement compiled with `?` markers therefore has to have its
+ * parameters written into the SQL before it goes out, which makes this the one
+ * place in the package where a mistake is an injection vulnerability rather
+ * than a bug.
+ *
+ * Prepared statements send parameters out of band and never come through here.
+ *
+ * @internal
+ */
+
+/**
+ * Characters MySQL requires to be escaped inside a single-quoted string, and
+ * their replacements.
+ *
+ * @internal
+ */
+const escapes: Record<string, string> = {
+  "\0": "\\0",
+  "\b": "\\b",
+  "\t": "\\t",
+  "\n": "\\n",
+  "\r": "\\r",
+  "\x1a": "\\Z",
+  "\"": "\\\"",
+  "'": "\\'",
+  "\\": "\\\\"
+}
+
+// NUL and Ctrl-Z are exactly the characters MySQL requires escaping, so
+// matching them here is the point.
+// eslint-disable-next-line no-control-regex
+const escapePattern = /[\0\b\t\n\r\x1a"'\\]/g
+
+/** @internal */
+export const escapeString = (value: string): string => `'${value.replace(escapePattern, (c) => escapes[c])}'`
+
+const hexDigits = "0123456789abcdef"
+
+const escapeBytes = (value: Uint8Array): string => {
+  let text = "X'"
+  for (let index = 0; index < value.length; index++) {
+    const byte = value[index]
+    text += hexDigits[byte >> 4] + hexDigits[byte & 0x0f]
+  }
+  return text + "'"
+}
+
+/**
+ * Formats a `Date` as a MySQL datetime literal in UTC, matching the session
+ * time zone the connection sets on connect.
+ *
+ * @internal
+ */
+const escapeDate = (value: Date): string => {
+  const time = value.getTime()
+  if (Number.isNaN(time)) {
+    throw new CodecError({ message: "Cannot bind an invalid Date" })
+  }
+  const pad = (n: number, width: number) => String(n).padStart(width, "0")
+  return escapeString(
+    `${pad(value.getUTCFullYear(), 4)}-${pad(value.getUTCMonth() + 1, 2)}-${pad(value.getUTCDate(), 2)} ` +
+      `${pad(value.getUTCHours(), 2)}:${pad(value.getUTCMinutes(), 2)}:${pad(value.getUTCSeconds(), 2)}.` +
+      `${pad(value.getUTCMilliseconds(), 3)}`
+  )
+}
+
+/**
+ * Renders one parameter as a SQL literal.
+ *
+ * @internal
+ */
+export const escapeValue = (value: unknown): string => {
+  if (value === null || value === undefined) return "NULL"
+  switch (typeof value) {
+    case "string":
+      return escapeString(value)
+    case "number":
+      if (!Number.isFinite(value)) {
+        throw new CodecError({ message: `Cannot bind the non-finite number ${value}` })
+      }
+      return String(value)
+    case "bigint":
+      return String(value)
+    case "boolean":
+      return value ? "1" : "0"
+    case "object":
+      break
+    default:
+      throw new CodecError({ message: `Cannot bind a value of type ${typeof value}` })
+  }
+  if (value instanceof Date) return escapeDate(value)
+  if (value instanceof Uint8Array) return escapeBytes(value)
+  if (value instanceof Int8Array) return escapeBytes(new Uint8Array(value.buffer, value.byteOffset, value.length))
+  // An array binds as a comma-separated list, which is what `sql.in` needs.
+  if (Array.isArray(value)) return value.map(escapeValue).join(", ")
+  // Anything else is stored as JSON, matching how a JSON column round-trips.
+  return escapeString(JSON.stringify(value))
+}
+
+/**
+ * Replaces each `?` placeholder in `sql` with its parameter.
+ *
+ * Placeholders inside string literals, quoted identifiers and comments are
+ * left alone, so a literal question mark in the statement text is never
+ * mistaken for a placeholder.
+ *
+ * @internal
+ */
+export const bindParameters = (sql: string, params: ReadonlyArray<unknown>): string => {
+  if (params.length === 0) return sql
+  let out = ""
+  let index = 0
+  let next = 0
+  while (index < sql.length) {
+    const char = sql[index]
+    switch (char) {
+      case "'":
+      case "\"":
+      case "`": {
+        // Copy the quoted run verbatim, honouring backslash escapes inside the
+        // two string quotes and the doubled-quote form used by all three.
+        const quote = char
+        const backslashes = quote !== "`"
+        let end = index + 1
+        while (end < sql.length) {
+          if (backslashes && sql[end] === "\\") {
+            end += 2
+            continue
+          }
+          if (sql[end] === quote) {
+            if (sql[end + 1] === quote) {
+              end += 2
+              continue
+            }
+            end += 1
+            break
+          }
+          end += 1
+        }
+        out += sql.slice(index, end)
+        index = end
+        continue
+      }
+      case "-":
+        if (sql[index + 1] === "-") {
+          const end = sql.indexOf("\n", index)
+          const stop = end === -1 ? sql.length : end
+          out += sql.slice(index, stop)
+          index = stop
+          continue
+        }
+        break
+      case "#": {
+        const end = sql.indexOf("\n", index)
+        const stop = end === -1 ? sql.length : end
+        out += sql.slice(index, stop)
+        index = stop
+        continue
+      }
+      case "/":
+        if (sql[index + 1] === "*") {
+          const end = sql.indexOf("*/", index + 2)
+          const stop = end === -1 ? sql.length : end + 2
+          out += sql.slice(index, stop)
+          index = stop
+          continue
+        }
+        break
+      case "?": {
+        if (next >= params.length) {
+          throw new CodecError({
+            message: `Statement has more placeholders than the ${params.length} parameter(s) supplied`
+          })
+        }
+        out += escapeValue(params[next++])
+        index += 1
+        continue
+      }
+    }
+    out += char
+    index += 1
+  }
+  if (next !== params.length) {
+    throw new CodecError({
+      message: `Statement has ${next} placeholder(s) but ${params.length} parameter(s) were supplied`
+    })
+  }
+  return out
+}

--- a/packages/sql/mysql/src/internal/flags.ts
+++ b/packages/sql/mysql/src/internal/flags.ts
@@ -1,0 +1,29 @@
+/**
+ * Arithmetic for MySQL's bit flags.
+ *
+ * MySQL carries several of these — capabilities, column flags, server status —
+ * and they are not interchangeable, so each is branded separately by the module
+ * that owns it. The arithmetic lives here rather than at call sites: the
+ * capability field is 32 bits wide, where `|` and `&` coerce to a signed
+ * integer and quietly return the wrong answer for the two highest flags.
+ *
+ * @internal
+ */
+export const has = (self: number, flag: number): boolean => Math.floor(self / flag) % 2 === 1
+
+/** @internal */
+export const add = (self: number, flag: number): number => has(self, flag) ? self : self + flag
+
+/** @internal */
+export const of = (flags: Iterable<number>): number => {
+  let total = 0
+  for (const flag of flags) total = add(total, flag)
+  return total
+}
+
+/** @internal */
+export const retain = (self: number, flags: Iterable<number>): number => {
+  let total = 0
+  for (const flag of flags) if (has(self, flag)) total = add(total, flag)
+  return total
+}

--- a/packages/sql/mysql/src/internal/packet.ts
+++ b/packages/sql/mysql/src/internal/packet.ts
@@ -1,0 +1,103 @@
+import { BufferError, type Reader } from "./buffer.ts"
+
+/**
+ * Describing a packet's layout as data.
+ *
+ * Most MySQL packets are a fixed sequence of fields, and writing them out as a
+ * run of `reader.uint8(); reader.uint16()` calls buries that shape in control
+ * flow. A packet declared here reads as its layout, and the decoded record's
+ * type follows from the declaration rather than being restated.
+ *
+ * This covers packets whose shape is known before reading them. A length that
+ * depends on an earlier field still needs a reader of its own, which `make`
+ * exists for.
+ *
+ * @internal
+ */
+
+/** Reads one field of a packet. */
+export interface Field<out A> {
+  readonly read: (reader: Reader) => A
+}
+
+/** Builds a field from a reader, for shapes the combinators do not cover. */
+export const make = <A>(read: (reader: Reader) => A): Field<A> => ({ read })
+
+/** @internal */
+export const uint8: Field<number> = make((reader) => reader.uint8())
+/** @internal */
+export const uint16: Field<number> = make((reader) => reader.uint16())
+/** @internal */
+export const uint32: Field<number> = make((reader) => reader.uint32())
+/** @internal */
+export const lenencInt: Field<number | bigint | null> = make((reader) => reader.lenencInt())
+/** @internal */
+export const lenencString: Field<string | null> = make((reader) => reader.lenencString())
+/** @internal */
+export const cString: Field<string> = make((reader) => reader.cString())
+/** @internal */
+export const restString: Field<string> = make((reader) => reader.restString())
+/** @internal */
+export const rest: Field<Uint8Array> = make((reader) => reader.rest())
+
+/** A run of bytes of known length. */
+export const bytes = (length: number): Field<Uint8Array> => make((reader) => reader.raw(length))
+
+/** A string of known length. */
+export const string = (length: number): Field<string> => make((reader) => reader.string(length))
+
+/** Bytes the packet carries but this client does not read. */
+export const skip = (length: number): Field<null> =>
+  make((reader) => {
+    reader.skip(length)
+    return null
+  })
+
+/**
+ * The byte a packet must open with. More than one is accepted where the same
+ * shape has two headers, as an OK packet does.
+ */
+export const tag = (...accepted: ReadonlyArray<number>): Field<number> =>
+  make((reader) => {
+    const value = reader.uint8()
+    if (!accepted.includes(value)) {
+      throw new BufferError({ message: `Unexpected header 0x${value.toString(16)}` })
+    }
+    return value
+  })
+
+/** A field the packet only carries when bytes are left. */
+export const whenPresent = <A>(inner: Field<A>): Field<A | undefined> =>
+  make((reader) => reader.offset < reader.limit ? inner.read(reader) : undefined)
+
+/** A field the packet only carries when the next byte marks it. */
+export const whenByte = <A>(marker: number, inner: Field<A>): Field<A | undefined> =>
+  make((reader) =>
+    reader.offset < reader.limit && reader.bytes[reader.offset] === marker ? inner.read(reader) : undefined
+  )
+
+/** @internal */
+export type Shape = Record<string, Field<any>>
+
+/** What a declared packet decodes to. */
+export type Decoded<S extends Shape> = {
+  readonly [K in keyof S]: S[K] extends Field<infer A> ? A : never
+}
+
+/**
+ * Turns a declaration into a decoder.
+ *
+ * The reader is supplied by the caller so one instance can be reused across
+ * packets, which is why this does not own one.
+ */
+export const decoder = <S extends Shape>(shape: S): (reader: Reader, payload: Uint8Array) => Decoded<S> => {
+  const fields = Object.entries(shape)
+  return (reader, payload) => {
+    reader.reset(payload, 0, payload.length)
+    const decoded: Record<string, unknown> = {}
+    for (let index = 0; index < fields.length; index++) {
+      decoded[fields[index][0]] = fields[index][1].read(reader)
+    }
+    return decoded as Decoded<S>
+  }
+}

--- a/packages/sql/mysql/src/internal/reply.ts
+++ b/packages/sql/mysql/src/internal/reply.ts
@@ -1,0 +1,374 @@
+/**
+ * Reading the reply to a command.
+ *
+ * These readers are programs over a stream of packets and nothing else: they
+ * hold no connection, so they can be driven by a socket or by packets written
+ * by hand, which is what makes them testable without a server.
+ *
+ * The row shape is a type parameter rather than a mode flag, so the reader
+ * that builds row objects and the one that builds value arrays are the same
+ * program read twice.
+ *
+ * @internal
+ */
+import * as Data from "effect/Data"
+import * as Effect from "effect/Effect"
+import * as Match from "effect/Match"
+import * as Queue from "effect/Queue"
+import * as EffectResult from "effect/Result"
+import { SqlError } from "effect/unstable/sql/SqlError"
+import * as MysqlProtocol from "../MysqlProtocol.ts"
+import * as MysqlTypes from "../MysqlTypes.ts"
+import { classifyErr, queryError } from "./sqlError.ts"
+
+export interface Prepared {
+  readonly statementId: number
+  readonly parameterCount: number
+}
+
+export type RowDecoder = (
+  columns: ReadonlyArray<MysqlProtocol.Column>
+) => (payload: Uint8Array) => EffectResult.Result<Array<unknown>, MysqlProtocol.ParseError>
+
+export const textRows = (options: MysqlTypes.DecodeOptions): RowDecoder => (columns) => {
+  const readField = MysqlTypes.makeTextFieldReader(columns, options)
+  return (payload) => MysqlProtocol.decodeTextRow(payload, columns.length, readField)
+}
+
+export const binaryRows = (options: MysqlTypes.DecodeOptions): RowDecoder => (columns) => {
+  const readField = MysqlTypes.makeBinaryFieldReader(columns, options)
+  return (payload) => MysqlProtocol.decodeBinaryRow(payload, columns.length, readField)
+}
+
+/**
+ * Reads the packets of the reply currently in flight.
+ *
+ * `one` is for the parts of a reply that are a fixed sequence, where reading
+ * it as a program is worth a step per packet. `chunk` is for the parts that
+ * repeat per row, where it is not: a socket chunk carries many rows, and
+ * crossing the Effect runtime for each of them costs more than decoding it.
+ */
+export interface PacketReader {
+  /** The next packet, waiting for one if the buffer is empty. */
+  readonly one: Effect.Effect<MysqlProtocol.Packet, SqlError>
+  /**
+   * The next packet already in hand, or `undefined` when the buffer is spent.
+   *
+   * A row loop reads through this so that a reply costs one trip through the
+   * Effect runtime per socket chunk rather than per row, without the reader
+   * losing track of where the caller got to: a caller that stops in the middle
+   * of a chunk leaves the rest of it readable.
+   */
+  readonly buffered: () => MysqlProtocol.Packet | undefined
+  /** Waits for more packets, once `buffered` has run out. */
+  readonly refill: Effect.Effect<void, SqlError>
+}
+
+/** Kept for the readers that take a reply one packet at a time. */
+export type Take = Effect.Effect<MysqlProtocol.Packet, SqlError>
+
+export const makeReader = (queue: Queue.Dequeue<MysqlProtocol.Packet, SqlError>): PacketReader => {
+  let batch: ReadonlyArray<MysqlProtocol.Packet> = []
+  let index = 0
+  return {
+    one: Effect.suspend(() => {
+      if (index < batch.length) return Effect.succeed(batch[index++])
+      return Effect.map(Queue.takeAll(queue), (next) => {
+        batch = next
+        index = 1
+        return next[0]
+      })
+    }),
+    buffered: () => index < batch.length ? batch[index++] : undefined,
+    refill: Effect.map(Queue.takeAll(queue), (next) => {
+      batch = next
+      index = 0
+    })
+  }
+}
+
+/** Lifts a decode result into the command, failing it on malformed bytes. */
+export const decodedAs = <A>(
+  result: EffectResult.Result<A, MysqlProtocol.ParseError>,
+  message: string,
+  operation: string
+): Effect.Effect<A, SqlError> =>
+  EffectResult.isSuccess(result)
+    ? Effect.succeed(result.success)
+    : Effect.fail(queryError(result.failure, message, operation))
+
+/** Takes a packet and decodes it. */
+export const take = <A>(
+  from: Take,
+  decode: (payload: Uint8Array) => EffectResult.Result<A, MysqlProtocol.ParseError>,
+  message: string,
+  operation: string
+): Effect.Effect<A, SqlError> => Effect.flatMap(from, (packet) => decodedAs(decode(packet.payload), message, operation))
+
+const serverError = (error: MysqlProtocol.Err, message: string, operation: string): SqlError =>
+  new SqlError({ reason: classifyErr(error, message, operation) })
+
+/**
+ * A finished statement, in whatever shape its rows were built.
+ *
+ * The shape is a type parameter rather than a mode flag, so a reader that
+ * builds arrays and one that builds row objects are the same program read
+ * twice, and neither has to widen its rows to `any`.
+ *
+ * Which of the two a statement produced is carried rather than inferred. The
+ * reply reader knows it from the response packet, and a consumer that has to
+ * work it out again from an empty column list is reconstructing something
+ * that was already certain.
+ */
+export type Completed<A> = Data.TaggedEnum<{
+  readonly ResultSet: {
+    readonly rows: ReadonlyArray<A>
+    readonly columns: ReadonlyArray<MysqlProtocol.Column>
+    readonly ok: MysqlProtocol.Ok
+  }
+  readonly Ok: {
+    readonly ok: MysqlProtocol.Ok
+  }
+}>
+
+/** @internal */
+export interface CompletedDefinition extends Data.TaggedEnum.WithGenerics<1> {
+  readonly taggedEnum: Completed<this["A"]>
+}
+
+/** @internal */
+export const Completed = Data.taggedEnum<CompletedDefinition>()
+
+/** Builds one row from its column-ordered values. */
+export type BuildRow<A> = (columns: ReadonlyArray<MysqlProtocol.Column>, values: ReadonlyArray<unknown>) => A
+
+export const readPrepared = Effect.fnUntraced(function*(from: Take): Effect.fn.Return<Prepared, SqlError> {
+  const packet = yield* from
+  if (packet.payload.length > 0 && packet.payload[0] === 0xff) {
+    const error = yield* take(
+      Effect.succeed(packet),
+      MysqlProtocol.decodeErr,
+      "MysqlConnection: Failed to read an error response",
+      "prepare"
+    )
+    return yield* Effect.fail(serverError(error, "MysqlConnection: Failed to prepare statement", "prepare"))
+  }
+  const ok = yield* decodedAs(
+    MysqlProtocol.decodeStmtPrepareOk(packet.payload),
+    "MysqlConnection: Failed to read a prepare response",
+    "prepare"
+  )
+  const definitions = ok.parameterCount + ok.columnCount
+  for (let index = 0; index < definitions; index++) yield* from
+  return { statementId: ok.statementId, parameterCount: ok.parameterCount }
+})
+
+/** Reads a result set, from its column definitions to its terminator. */
+const readResultSet = Effect.fnUntraced(function*<A>(
+  reader: PacketReader,
+  columnCount: number,
+  rowDecoder: RowDecoder,
+  buildRow: BuildRow<A>
+): Effect.fn.Return<Completed<A>, SqlError> {
+  const columns = yield* readColumns(reader.one, columnCount, "execute")
+  // The columns are known from here on, so the decoder and the rows it
+  // produces cannot be reached before they exist.
+  const decodeRow = rowDecoder(columns)
+  const rows: Array<A> = []
+  // A value this client cannot read is the statement's problem, not the
+  // session's, so the rest of the reply is still read before failing.
+  // Abandoning it here would desync the next command instead.
+  let undecodable: SqlError | undefined
+  while (true) {
+    const packet = reader.buffered()
+    if (packet === undefined) {
+      yield* reader.refill
+      continue
+    }
+    const next = yield* decodedAs(
+      MysqlProtocol.decodeRow(packet.payload),
+      "MysqlConnection: Failed to read a row",
+      "execute"
+    )
+    if (MysqlProtocol.RowPacket.$is("End")(next)) {
+      if (undecodable !== undefined) return yield* Effect.fail(undecodable)
+      return Completed.ResultSet({ rows, columns, ok: next.ok })
+    }
+    if (MysqlProtocol.RowPacket.$is("Error")(next)) {
+      return yield* Effect.fail(serverError(next.error, "MysqlConnection: Failed to execute statement", "execute"))
+    }
+    if (undecodable !== undefined) continue
+    const values = decodeRow(next.payload)
+    if (EffectResult.isFailure(values)) {
+      undecodable = queryError(values.failure, "MysqlConnection: Failed to read a row", "execute")
+      continue
+    }
+    rows.push(buildRow(columns, values.success))
+  }
+})
+
+/**
+ * Reads a command's reply: one entry per statement, in order.
+ */
+export const readReply = Effect.fnUntraced(function*<A>(
+  reader: PacketReader,
+  rowDecoder: RowDecoder,
+  buildRow: BuildRow<A>
+): Effect.fn.Return<ReadonlyArray<Completed<A>>, SqlError> {
+  const statements: Array<Completed<A>> = []
+  while (true) {
+    const response = yield* take(
+      reader.one,
+      MysqlProtocol.decodeResponse,
+      "MysqlConnection: Failed to read a response",
+      "execute"
+    )
+    const finished = yield* Match.value(response).pipe(
+      Match.tagsExhaustive({
+        Ok: ({ ok }): Effect.Effect<Completed<A>, SqlError> => Effect.succeed(Completed.Ok({ ok })),
+        Error: ({ error }) =>
+          Effect.fail(serverError(error, "MysqlConnection: Failed to execute statement", "execute")),
+        LocalInfile: () => Effect.fail(localInfileRefused("execute")),
+        ResultSet: ({ columnCount }) => readResultSet(reader, columnCount, rowDecoder, buildRow)
+      })
+    )
+    statements.push(finished)
+    if (
+      !MysqlProtocol.ServerStatus.has(finished.ok.statusFlags, MysqlProtocol.ServerStatusFlag.moreResultsExists)
+    ) {
+      return statements
+    }
+  }
+})
+
+export const readAcknowledgement = (from: Take, message: string, operation: string): Effect.Effect<void, SqlError> =>
+  Effect.flatMap(
+    take(from, MysqlProtocol.decodeResponse, message, operation),
+    (response) =>
+      MysqlProtocol.Response.$is("Error")(response)
+        ? Effect.fail(serverError(response.error, message, operation))
+        : Effect.void
+  )
+
+const readColumns = Effect.fnUntraced(function*(
+  from: Take,
+  columnCount: number,
+  operation: string
+): Effect.fn.Return<Array<MysqlProtocol.Column>, SqlError> {
+  const columns: Array<MysqlProtocol.Column> = []
+  for (let index = 0; index < columnCount; index++) {
+    columns.push(
+      yield* take(from, MysqlProtocol.decodeColumn, "MysqlConnection: Failed to read a column definition", operation)
+    )
+  }
+  return columns
+})
+
+const streamResultSet = Effect.fnUntraced(function*<A>(
+  reader: PacketReader,
+  columnCount: number,
+  rowDecoder: RowDecoder,
+  buildRow: BuildRow<A>,
+  push: (row: A) => void
+): Effect.fn.Return<MysqlProtocol.ServerStatus, SqlError> {
+  const columns = yield* readColumns(reader.one, columnCount, "stream")
+  const decodeRow = rowDecoder(columns)
+  while (true) {
+    const packet = reader.buffered()
+    if (packet === undefined) {
+      yield* reader.refill
+      continue
+    }
+    const next = yield* decodedAs(
+      MysqlProtocol.decodeRow(packet.payload),
+      "MysqlConnection: Failed to read a row",
+      "stream"
+    )
+    if (MysqlProtocol.RowPacket.$is("End")(next)) return next.ok.statusFlags
+    if (MysqlProtocol.RowPacket.$is("Error")(next)) {
+      return yield* Effect.fail(serverError(next.error, "MysqlConnection: Failed to stream statement", "stream"))
+    }
+    const values = yield* decodedAs(decodeRow(next.payload), "MysqlConnection: Failed to read a row", "stream")
+    push(buildRow(columns, values))
+  }
+})
+
+/**
+ * Reads whatever is left of a reply and throws it away.
+ *
+ * A cancelled statement still finishes on the wire, as either a result-set
+ * terminator or an error, and the session cannot be reused until that has been
+ * read.
+ *
+ * This must take over the reader's own `Take`, not a fresh one: taking refills
+ * a chunk at a time, so an interrupted reader can be holding packets that have
+ * already left the queue - including, if the whole reply arrived at once, the
+ * terminator this is looking for.
+ */
+export const drainReply = Effect.fnUntraced(function*(from: Take): Effect.fn.Return<void, SqlError> {
+  while (true) {
+    const payload = (yield* from).payload
+    if (payload.length === 0) continue
+    if (payload[0] === 0xff) return
+    if (payload[0] === 0xfe && payload.length < 9) return
+  }
+})
+
+/** How many rows accumulate before a streaming read hands them over. */
+const streamBatchSize = 64
+
+/**
+ * Reads a reply, emitting rows as they arrive instead of collecting them.
+ *
+ * Rows are handed over in batches: offering each one separately would cost a
+ * queue round per row, and a result set delivers them in bulk.
+ */
+export const readStream = <A>(
+  reader: PacketReader,
+  rowDecoder: RowDecoder,
+  buildRow: BuildRow<A>,
+  emit: { readonly array: (rows: ReadonlyArray<A>) => void }
+): Effect.Effect<void, SqlError> =>
+  Effect.suspend(() => {
+    let buffered: Array<A> = []
+    const flush = (): void => {
+      if (buffered.length === 0) return
+      const batch = buffered
+      buffered = []
+      emit.array(batch)
+    }
+    const push = (row: A): void => {
+      buffered.push(row)
+      if (buffered.length >= streamBatchSize) flush()
+    }
+
+    return Effect.gen(function*() {
+      while (true) {
+        const response = yield* take(
+          reader.one,
+          MysqlProtocol.decodeResponse,
+          "MysqlConnection: Failed to read a response",
+          "stream"
+        )
+        const status = yield* Match.value(response).pipe(
+          Match.tagsExhaustive({
+            Ok: ({ ok }) => Effect.succeed(ok.statusFlags),
+            Error: ({ error }) => Effect.fail(streamFailed(error)),
+            LocalInfile: () => Effect.fail(localInfileRefused("stream")),
+            ResultSet: ({ columnCount }) => streamResultSet(reader, columnCount, rowDecoder, buildRow, push)
+          })
+        )
+        if (!MysqlProtocol.ServerStatus.has(status, MysqlProtocol.ServerStatusFlag.moreResultsExists)) return
+      }
+    }).pipe(Effect.onExit(() => Effect.sync(flush)))
+  })
+
+const streamFailed = (error: MysqlProtocol.Err): SqlError =>
+  serverError(error, "MysqlConnection: Failed to stream statement", "stream")
+
+const localInfileRefused = (operation: string): SqlError =>
+  queryError(
+    new Error("The server requested a LOCAL INFILE transfer"),
+    "MysqlConnection: LOCAL INFILE is not enabled",
+    operation
+  )

--- a/packages/sql/mysql/src/internal/sqlError.ts
+++ b/packages/sql/mysql/src/internal/sqlError.ts
@@ -1,0 +1,118 @@
+import {
+  AuthenticationError,
+  AuthorizationError,
+  ConnectionError,
+  ConstraintError,
+  DeadlockError,
+  LockTimeoutError,
+  SerializationError,
+  SqlError,
+  type SqlErrorReason,
+  SqlSyntaxError,
+  StatementTimeoutError,
+  UniqueViolation,
+  UnknownError
+} from "effect/unstable/sql/SqlError"
+import type * as MysqlProtocol from "../MysqlProtocol.ts"
+
+/** @internal */
+export interface ErrorProps {
+  readonly cause: unknown
+  readonly message: string
+  readonly operation: string
+}
+
+/**
+ * Server error numbers, grouped by the reason they map to. A number here beats
+ * the SQLSTATE class, because MySQL reuses a few broad states for errors that
+ * differ in whether a retry can help.
+ *
+ * @internal
+ */
+const connectionErrnos = new Set([1040, 1042, 1043, 1129, 1130, 1152, 1153, 1158, 1159, 1160, 1161, 1203])
+/** @internal */
+const authorizationErrnos = new Set([1044, 1142, 1143, 1227])
+/** @internal */
+const syntaxErrnos = new Set([1054, 1064, 1146])
+/** @internal */
+const constraintErrnos = new Set([1022, 1048, 1169, 1216, 1217, 1451, 1452, 1557])
+
+const UNKNOWN_CONSTRAINT = "unknown"
+
+const normalizeConstraint = (identifier: string | undefined): string => {
+  if (typeof identifier !== "string") return UNKNOWN_CONSTRAINT
+  const trimmed = identifier.trim()
+  return trimmed.length === 0 ? UNKNOWN_CONSTRAINT : trimmed
+}
+
+/**
+ * Recovers the index name from a duplicate-entry message, which is the only
+ * place the server reports it. The name may be quoted with `'` or a backtick,
+ * or unquoted.
+ *
+ * @internal
+ */
+export const constraintFromMessage = (message: string | undefined): string => {
+  if (typeof message !== "string") return UNKNOWN_CONSTRAINT
+  const match = /\bfor key\s+(?:'([^']*)'|`([^`]*)`|([^\s'`]+))/i.exec(message)
+  return match === null ? UNKNOWN_CONSTRAINT : normalizeConstraint(match[1] ?? match[2] ?? match[3])
+}
+
+/**
+ * Maps a server error onto an Effect SQL reason.
+ *
+ * The error number is consulted first and the SQLSTATE class second, so an
+ * error the table does not name still lands in the right family.
+ *
+ * @internal
+ */
+export const classifyErrno = (
+  errno: number | undefined,
+  sqlState: string | undefined,
+  serverMessage: string | undefined,
+  props: ErrorProps
+): SqlErrorReason => {
+  if (errno !== undefined) {
+    if (connectionErrnos.has(errno)) return new ConnectionError(props)
+    if (errno === 1045) return new AuthenticationError(props)
+    if (authorizationErrnos.has(errno)) return new AuthorizationError(props)
+    if (syntaxErrnos.has(errno)) return new SqlSyntaxError(props)
+    if (errno === 1062) {
+      return new UniqueViolation({ ...props, constraint: constraintFromMessage(serverMessage) })
+    }
+    if (constraintErrnos.has(errno)) return new ConstraintError(props)
+    if (errno === 1213) return new DeadlockError(props)
+    if (errno === 1205) return new LockTimeoutError(props)
+    if (errno === 3024) return new StatementTimeoutError(props)
+  }
+  if (sqlState !== undefined) {
+    if (sqlState === "40001") return new SerializationError(props)
+    if (sqlState.startsWith("08")) return new ConnectionError(props)
+    if (sqlState.startsWith("28")) return new AuthenticationError(props)
+    if (sqlState.startsWith("42")) return new SqlSyntaxError(props)
+    if (sqlState.startsWith("23")) return new ConstraintError(props)
+  }
+  return new UnknownError(props)
+}
+
+/** @internal */
+export const queryError = (cause: unknown, message: string, operation: string): SqlError =>
+  new SqlError({ reason: new UnknownError({ cause, message, operation }) })
+
+/** @internal */
+export const connectionError = (cause: unknown, message: string, operation: string): SqlError =>
+  new SqlError({ reason: new ConnectionError({ cause, message, operation }) })
+
+/**
+ * Turns an ERR packet into the reason it stands for.
+ *
+ * @internal
+ */
+export const classifyErr = (err: MysqlProtocol.Err, message: string, operation: string): SqlErrorReason => {
+  const cause = Object.assign(new Error(err.message), {
+    errno: err.code,
+    sqlState: err.sqlState,
+    sqlMessage: err.message
+  })
+  return classifyErrno(err.code, err.sqlState, err.message, { cause, message, operation })
+}

--- a/packages/sql/mysql/test/Client.integration.test.ts
+++ b/packages/sql/mysql/test/Client.integration.test.ts
@@ -1,0 +1,123 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { SqlClient } from "effect/unstable/sql"
+import { MysqlContainer } from "./utils.ts"
+
+describe("MysqlClient", () => {
+  it.layer(MysqlContainer.layer, { timeout: "120 seconds", excludeTestServices: true })(
+    "against a real server",
+    (it) => {
+      it.effect("runs a tagged statement", () =>
+        Effect.gen(function*() {
+          const sql = yield* SqlClient.SqlClient
+          assert.deepStrictEqual(yield* sql`SELECT 1 AS n`, [{ n: 1n }])
+        }).pipe(Effect.provide(MysqlContainer.client)), { timeout: 60_000 })
+
+      it.effect("binds parameters", () =>
+        Effect.gen(function*() {
+          const sql = yield* SqlClient.SqlClient
+          const name = "O'Brien"
+          assert.deepStrictEqual(yield* sql`SELECT ${name} AS name`, [{ name: "O'Brien" }])
+        }).pipe(Effect.provide(MysqlContainer.client)), { timeout: 60_000 })
+
+      it.effect("quotes identifiers with backticks", () =>
+        Effect.gen(function*() {
+          const sql = yield* SqlClient.SqlClient
+          yield* sql`CREATE TABLE ${sql("select")} (${sql("order")} INT)`
+          yield* sql`INSERT INTO ${sql("select")} (${sql("order")}) VALUES (1)`
+          assert.deepStrictEqual(yield* sql`SELECT * FROM ${sql("select")}`, [{ order: 1 }])
+        }).pipe(Effect.provide(MysqlContainer.client)), { timeout: 60_000 })
+
+      it.effect("inserts records and reads them back", () =>
+        Effect.gen(function*() {
+          const sql = yield* SqlClient.SqlClient
+          yield* sql`CREATE TABLE people (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(64), age INT)`
+          yield* sql`INSERT INTO people ${sql.insert([{ name: "alice", age: 30 }, { name: "bob", age: 40 }])}`
+          const rows = yield* sql`SELECT name, age FROM people ORDER BY id`
+          assert.deepStrictEqual(rows, [{ name: "alice", age: 30 }, { name: "bob", age: 40 }])
+        }).pipe(Effect.provide(MysqlContainer.client)), { timeout: 60_000 })
+
+      it.effect("expands sql.in", () =>
+        Effect.gen(function*() {
+          const sql = yield* SqlClient.SqlClient
+          yield* sql`CREATE TABLE nums (n INT)`
+          yield* sql`INSERT INTO nums ${sql.insert([{ n: 1 }, { n: 2 }, { n: 3 }])}`
+          const rows = yield* sql`SELECT n FROM nums WHERE ${sql.in("n", [1, 3])} ORDER BY n`
+          assert.deepStrictEqual(rows, [{ n: 1 }, { n: 3 }])
+        }).pipe(Effect.provide(MysqlContainer.client)), { timeout: 60_000 })
+
+      it.effect("commits a transaction", () =>
+        Effect.gen(function*() {
+          const sql = yield* SqlClient.SqlClient
+          yield* sql`CREATE TABLE tx_commit (n INT)`
+          yield* sql.withTransaction(sql`INSERT INTO tx_commit (n) VALUES (1)`)
+          assert.deepStrictEqual(yield* sql`SELECT n FROM tx_commit`, [{ n: 1 }])
+        }).pipe(Effect.provide(MysqlContainer.client)), { timeout: 60_000 })
+
+      it.effect("rolls a transaction back on failure", () =>
+        Effect.gen(function*() {
+          const sql = yield* SqlClient.SqlClient
+          yield* sql`CREATE TABLE tx_rollback (n INT)`
+          const failed = yield* Effect.flip(sql.withTransaction(Effect.gen(function*() {
+            yield* sql`INSERT INTO tx_rollback (n) VALUES (1)`
+            return yield* Effect.fail(new Error("nope"))
+          })))
+          assert.strictEqual(failed.message, "nope")
+          assert.deepStrictEqual(yield* sql`SELECT n FROM tx_rollback`, [])
+        }).pipe(Effect.provide(MysqlContainer.client)), { timeout: 60_000 })
+
+      it.effect("rolls a nested transaction back to its savepoint", () =>
+        Effect.gen(function*() {
+          const sql = yield* SqlClient.SqlClient
+          yield* sql`CREATE TABLE tx_savepoint (n INT)`
+          yield* sql.withTransaction(Effect.gen(function*() {
+            yield* sql`INSERT INTO tx_savepoint (n) VALUES (1)`
+            yield* Effect.ignore(sql.withTransaction(Effect.gen(function*() {
+              yield* sql`INSERT INTO tx_savepoint (n) VALUES (2)`
+              return yield* Effect.fail(new Error("inner"))
+            })))
+          }))
+          // The outer insert survives; only the savepoint is undone.
+          assert.deepStrictEqual(yield* sql`SELECT n FROM tx_savepoint`, [{ n: 1 }])
+        }).pipe(Effect.provide(MysqlContainer.client)), { timeout: 60_000 })
+
+      it.effect("returns the insert id through raw results", () =>
+        Effect.gen(function*() {
+          const sql = yield* SqlClient.SqlClient
+          yield* sql`CREATE TABLE raw_ids (id INT AUTO_INCREMENT PRIMARY KEY, n INT)`
+          const raw: any = yield* sql`INSERT INTO raw_ids (n) VALUES (7)`.raw
+          assert.strictEqual(raw.affectedRows, 1)
+          assert.strictEqual(raw.lastInsertId, 1)
+        }).pipe(Effect.provide(MysqlContainer.client)), { timeout: 60_000 })
+
+      it.effect("returns rows as arrays", () =>
+        Effect.gen(function*() {
+          const sql = yield* SqlClient.SqlClient
+          assert.deepStrictEqual(yield* sql`SELECT 1 AS a, 'b' AS b`.values, [[1n, "b"]])
+        }).pipe(Effect.provide(MysqlContainer.client)), { timeout: 60_000 })
+
+      it.effect("applies name transforms in both directions", () =>
+        Effect.gen(function*() {
+          const sql = yield* SqlClient.SqlClient
+          yield* sql`CREATE TABLE transformed (user_id INT, full_name VARCHAR(64))`
+          yield* sql`INSERT INTO transformed ${sql.insert({ userId: 1, fullName: "alice" })}`
+          assert.deepStrictEqual(yield* sql`SELECT * FROM transformed`, [{ userId: 1, fullName: "alice" }])
+        }).pipe(Effect.provide(MysqlContainer.clientWithTransforms)), { timeout: 60_000 })
+
+      it.effect("stores and reads JSON", () =>
+        Effect.gen(function*() {
+          const sql = yield* SqlClient.SqlClient
+          yield* sql`CREATE TABLE docs (body JSON)`
+          yield* sql`INSERT INTO docs (body) VALUES (${sql.unsafe(`'{"a":1}'`)})`
+          assert.deepStrictEqual(yield* sql`SELECT body FROM docs`, [{ body: { a: 1 } }])
+        }).pipe(Effect.provide(MysqlContainer.client)), { timeout: 60_000 })
+
+      it.effect("takes the mysql branch of onDialectOrElse", () =>
+        Effect.gen(function*() {
+          const sql = yield* SqlClient.SqlClient
+          const dialect = sql.onDialectOrElse({ mysql: () => "mysql", orElse: () => "other" })
+          assert.strictEqual(dialect, "mysql")
+        }).pipe(Effect.provide(MysqlContainer.client)), { timeout: 60_000 })
+    }
+  )
+})

--- a/packages/sql/mysql/test/KeyValueStore.integration.test.ts
+++ b/packages/sql/mysql/test/KeyValueStore.integration.test.ts
@@ -1,0 +1,16 @@
+import { Layer } from "effect"
+import * as KeyValueStoreTest from "effect-test/unstable/persistence/KeyValueStoreTest"
+import * as KeyValueStore from "effect/unstable/persistence/KeyValueStore"
+import { MysqlContainer } from "./utils.ts"
+
+KeyValueStoreTest.suite(
+  "sql-mysql",
+  KeyValueStore.layerSql().pipe(Layer.provide(MysqlContainer.layerClient))
+)
+
+KeyValueStoreTest.suite(
+  "sql-mysql-custom-table",
+  KeyValueStore.layerSql({ table: "effect_key_value_store_custom" }).pipe(
+    Layer.provide(MysqlContainer.layerClient)
+  )
+)

--- a/packages/sql/mysql/test/Migrator.integration.test.ts
+++ b/packages/sql/mysql/test/Migrator.integration.test.ts
@@ -1,0 +1,59 @@
+import { NodeServices } from "@effect/platform-node"
+import { MysqlMigrator } from "@effect/sql-mysql"
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Layer } from "effect"
+import { SqlClient } from "effect/unstable/sql"
+import { MysqlContainer } from "./utils.ts"
+
+/** Each test migrates its own tables, since they share one database. */
+const migrations = (table: string) =>
+  MysqlMigrator.fromRecord({
+    [`1_create_${table}`]: Effect.gen(function*() {
+      const sql = yield* SqlClient.SqlClient
+      yield* sql`CREATE TABLE ${sql(table)} (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(64))`
+    }),
+    [`2_add_colour_to_${table}`]: Effect.gen(function*() {
+      const sql = yield* SqlClient.SqlClient
+      yield* sql`ALTER TABLE ${sql(table)} ADD COLUMN colour VARCHAR(32)`
+    })
+  })
+
+describe("MysqlMigrator", () => {
+  it.layer(Layer.merge(MysqlContainer.layerClient, NodeServices.layer), { timeout: "120 seconds" })(
+    "against a real server",
+    (it) => {
+      it.effect("applies pending migrations once", () =>
+        Effect.gen(function*() {
+          const sql = yield* SqlClient.SqlClient
+          const applied = yield* MysqlMigrator.run({
+            loader: migrations("widgets"),
+            table: "widget_migrations"
+          })
+          assert.deepStrictEqual(applied, [[1, "create_widgets"], [2, "add_colour_to_widgets"]])
+
+          // The migrated schema is really there.
+          yield* sql`INSERT INTO widgets ${sql.insert({ name: "cog", colour: "red" })}`
+          assert.deepStrictEqual(yield* sql`SELECT name, colour FROM widgets`, [{ name: "cog", colour: "red" }])
+
+          // Running again applies nothing, because the migrations table records
+          // what has already been applied.
+          const again = yield* MysqlMigrator.run({
+            loader: migrations("widgets"),
+            table: "widget_migrations"
+          })
+          assert.deepStrictEqual(again, [])
+        }), { timeout: 60_000 })
+
+      it.effect("records applied migrations in its table", () =>
+        Effect.gen(function*() {
+          const sql = yield* SqlClient.SqlClient
+          yield* MysqlMigrator.run({ loader: migrations("gadgets"), table: "gadget_migrations" })
+          const rows = yield* sql`SELECT migration_id, name FROM gadget_migrations ORDER BY migration_id`
+          assert.deepStrictEqual(rows, [
+            { migration_id: 1, name: "create_gadgets" },
+            { migration_id: 2, name: "add_colour_to_gadgets" }
+          ])
+        }), { timeout: 60_000 })
+    }
+  )
+})

--- a/packages/sql/mysql/test/Model.integration.test.ts
+++ b/packages/sql/mysql/test/Model.integration.test.ts
@@ -1,0 +1,71 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Schema } from "effect"
+import { Model } from "effect/unstable/schema"
+import { SqlClient, SqlModel } from "effect/unstable/sql"
+import { MysqlContainer } from "./utils.ts"
+
+class User extends Model.Class<User>("User")({
+  id: Schema.Int.pipe(Model.FieldExcept(["insert"])),
+  name: Schema.String,
+  age: Schema.Int
+}) {}
+
+describe("SqlModel", () => {
+  it.layer(MysqlContainer.layer, { timeout: "120 seconds", excludeTestServices: true })(
+    "against a real server",
+    (it) => {
+      it.effect("insert returns the inserted row", () =>
+        Effect.gen(function*() {
+          const repo = yield* SqlModel.makeRepository(User, {
+            tableName: "users_insert",
+            idColumn: "id",
+            spanPrefix: "UserRepository"
+          })
+          const sql = yield* SqlClient.SqlClient
+          yield* sql`CREATE TABLE users_insert (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), age INT)`
+
+          // MySQL has no RETURNING, so the core issues the insert and a
+          // LAST_INSERT_ID select as one multi-statement text command.
+          const result = yield* repo.insert(User.insert.make({ name: "Alice", age: 30 }))
+          assert.deepStrictEqual(result, new User({ id: 1, name: "Alice", age: 30 }))
+        }).pipe(Effect.provide(MysqlContainer.client)), { timeout: 60_000 })
+
+      it.effect("insert returns the inserted row with transforms", () =>
+        Effect.gen(function*() {
+          const repo = yield* SqlModel.makeRepository(User, {
+            tableName: "users_transforms",
+            idColumn: "id",
+            spanPrefix: "UserRepository"
+          })
+          const sql = yield* SqlClient.SqlClient
+          yield* sql`CREATE TABLE users_transforms (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), age INT)`
+
+          const result = yield* repo.insert(User.insert.make({ name: "Alice", age: 30 }))
+          assert.deepStrictEqual(result, new User({ id: 1, name: "Alice", age: 30 }))
+        }).pipe(Effect.provide(MysqlContainer.clientWithTransforms)), { timeout: 60_000 })
+
+      it.effect("insertVoid, findById and update round-trip", () =>
+        Effect.gen(function*() {
+          const repo = yield* SqlModel.makeRepository(User, {
+            tableName: "users_crud",
+            idColumn: "id",
+            spanPrefix: "UserRepository"
+          })
+          const sql = yield* SqlClient.SqlClient
+          yield* sql`CREATE TABLE users_crud (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), age INT)`
+
+          yield* repo.insertVoid(User.insert.make({ name: "Bob", age: 40 }))
+          const found = yield* repo.findById(1)
+          assert.deepStrictEqual(found, new User({ id: 1, name: "Bob", age: 40 }))
+
+          const updated = yield* repo.update(new User({ id: 1, name: "Bobby", age: 41 }))
+          assert.deepStrictEqual(updated, new User({ id: 1, name: "Bobby", age: 41 }))
+
+          yield* repo.delete(1)
+          // findById fails rather than returning an Option when the row is gone.
+          const missing = yield* Effect.flip(repo.findById(1))
+          assert.strictEqual(missing._tag, "NoSuchElementError")
+        }).pipe(Effect.provide(MysqlContainer.client)), { timeout: 60_000 })
+    }
+  )
+})

--- a/packages/sql/mysql/test/MysqlAuth.test.ts
+++ b/packages/sql/mysql/test/MysqlAuth.test.ts
@@ -1,0 +1,188 @@
+import { MysqlAuth } from "@effect/sql-mysql"
+import { assert, describe, it } from "@effect/vitest"
+import * as Result from "effect/Result"
+import * as crypto from "node:crypto"
+
+const hex = (value: Uint8Array): string => Array.from(value, (byte) => byte.toString(16).padStart(2, "0")).join("")
+
+const success = <A, E>(result: Result.Result<A, E>): A => {
+  assert.isTrue(Result.isSuccess(result), "expected a success")
+  return (result as Result.Success<A, E>).success
+}
+
+const failure = <A, E>(result: Result.Result<A, E>): E => {
+  assert.isTrue(Result.isFailure(result), "expected a failure")
+  return (result as Result.Failure<A, E>).failure
+}
+
+/** The scramble used by every golden below: bytes 0x00 through 0x13. */
+const scramble = new Uint8Array(Array.from({ length: 20 }, (_, index) => index))
+
+describe("MysqlAuth", () => {
+  describe("mysql_native_password", () => {
+    it("matches the reference token", () => {
+      const token = success(MysqlAuth.nativePassword({ password: "secret", scramble }))
+      assert.strictEqual(hex(token), "21b3ff405f32cbe4aafff291396046ea29fa3a4d")
+    })
+
+    it("is always twenty bytes", () => {
+      assert.strictEqual(success(MysqlAuth.nativePassword({ password: "a", scramble })).length, 20)
+    })
+
+    it("sends nothing for an empty password", () => {
+      assert.strictEqual(success(MysqlAuth.nativePassword({ password: "", scramble })).length, 0)
+    })
+
+    it("changes with the scramble", () => {
+      const other = new Uint8Array(scramble)
+      other[19] ^= 0xff
+      assert.notStrictEqual(
+        hex(success(MysqlAuth.nativePassword({ password: "secret", scramble }))),
+        hex(success(MysqlAuth.nativePassword({ password: "secret", scramble: other })))
+      )
+    })
+
+    it("rejects a scramble of the wrong length", () => {
+      const error = failure(MysqlAuth.nativePassword({ password: "secret", scramble: new Uint8Array(8) }))
+      assert.strictEqual(error._tag, "MysqlAuthError")
+    })
+  })
+
+  describe("caching_sha2_password", () => {
+    it("matches the reference fast-auth token", () => {
+      const token = success(MysqlAuth.cachingSha2Password({ password: "secret", scramble }))
+      assert.strictEqual(hex(token), "6c84c617ec1f26456a02c42ed7cb02eca7d8511333f98bc9b31e5f68ce1665d5")
+    })
+
+    it("is always thirty-two bytes", () => {
+      assert.strictEqual(success(MysqlAuth.cachingSha2Password({ password: "a", scramble })).length, 32)
+    })
+
+    it("sends nothing for an empty password", () => {
+      assert.strictEqual(success(MysqlAuth.cachingSha2Password({ password: "", scramble })).length, 0)
+    })
+
+    it("NUL-terminates a cleartext password", () => {
+      assert.strictEqual(hex(MysqlAuth.cleartextPassword("secret")), "73656372657400")
+    })
+
+    it("encrypts a password the server can recover", () => {
+      const { privateKey, publicKey } = crypto.generateKeyPairSync("rsa", {
+        modulusLength: 2048,
+        publicKeyEncoding: { type: "spki", format: "pem" },
+        privateKeyEncoding: { type: "pkcs8", format: "pem" }
+      })
+      const encrypted = success(MysqlAuth.encryptedPassword({
+        password: "secret",
+        scramble,
+        publicKey
+      }))
+      const decrypted = crypto.privateDecrypt({
+        key: privateKey,
+        padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+        oaepHash: "sha1"
+      }, encrypted)
+      // The server undoes the XOR with the scramble it sent, then strips the NUL.
+      assert.strictEqual(hex(new Uint8Array(decrypted)), "73646171617106")
+    })
+
+    it("fails on a malformed public key", () => {
+      const error = failure(MysqlAuth.encryptedPassword({
+        password: "secret",
+        scramble,
+        publicKey: "not a key"
+      }))
+      assert.strictEqual(error._tag, "MysqlAuthError")
+    })
+  })
+
+  describe("respond", () => {
+    const bytesOf = (reply: MysqlAuth.Reply) => hex(reply.bytes)
+
+    it("dispatches on the plugin name", () => {
+      assert.strictEqual(
+        bytesOf(success(MysqlAuth.respond({
+          plugin: "mysql_native_password",
+          password: "secret",
+          scramble,
+          usingTls: false
+        }))),
+        hex(success(MysqlAuth.nativePassword({ password: "secret", scramble })))
+      )
+      assert.strictEqual(
+        bytesOf(success(MysqlAuth.respond({
+          plugin: "caching_sha2_password",
+          password: "secret",
+          scramble,
+          usingTls: false
+        }))),
+        hex(success(MysqlAuth.cachingSha2Password({ password: "secret", scramble })))
+      )
+    })
+
+    it("hands sha256_password the plain password over TLS", () => {
+      const reply = success(MysqlAuth.respond({
+        plugin: "sha256_password",
+        password: "secret",
+        scramble,
+        usingTls: true
+      }))
+      assert.strictEqual(reply._tag, "Respond")
+      assert.strictEqual(bytesOf(reply), "73656372657400")
+    })
+
+    it("asks sha256_password for a key on a plaintext socket", () => {
+      const reply = success(MysqlAuth.respond({
+        plugin: "sha256_password",
+        password: "secret",
+        scramble,
+        usingTls: false
+      }))
+      assert.strictEqual(reply._tag, "RequestPublicKey")
+      assert.strictEqual(bytesOf(reply), "01")
+    })
+
+    it("needs no key for sha256_password when there is no password", () => {
+      const reply = success(MysqlAuth.respond({
+        plugin: "sha256_password",
+        password: "",
+        scramble,
+        usingTls: false
+      }))
+      assert.strictEqual(reply._tag, "Respond")
+      assert.strictEqual(bytesOf(reply), "00")
+    })
+
+    it("sends mysql_clear_password only over TLS", () => {
+      const reply = success(MysqlAuth.respond({
+        plugin: "mysql_clear_password",
+        password: "secret",
+        scramble,
+        usingTls: true
+      }))
+      assert.strictEqual(bytesOf(reply), "73656372657400")
+    })
+
+    it("refuses mysql_clear_password on a plaintext socket", () => {
+      const error = failure(MysqlAuth.respond({
+        plugin: "mysql_clear_password",
+        password: "secret",
+        scramble,
+        usingTls: false
+      }))
+      assert.strictEqual(error._tag, "MysqlAuthError")
+      assert.match(error.message, /requires TLS/)
+    })
+
+    it("rejects an unsupported plugin", () => {
+      const error = failure(MysqlAuth.respond({
+        plugin: "authentication_kerberos_client",
+        password: "secret",
+        scramble,
+        usingTls: true
+      }))
+      assert.strictEqual(error._tag, "MysqlAuthError")
+      assert.include(error.message, "authentication_kerberos_client")
+    })
+  })
+})

--- a/packages/sql/mysql/test/MysqlConnection.in-process.test.ts
+++ b/packages/sql/mysql/test/MysqlConnection.in-process.test.ts
@@ -1,0 +1,240 @@
+import { MysqlConnection, MysqlProtocol } from "@effect/sql-mysql"
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Fiber, Result } from "effect"
+import * as TestClock from "effect/testing/TestClock"
+import * as Net from "node:net"
+
+/**
+ * A MySQL server that exists only to say something specific. The real server
+ * is reliable, which is exactly what makes it useless for these cases: a
+ * sequence-id gap, a capability it will never withhold, a socket that dies
+ * mid-command. Each test scripts the bytes it needs and asserts what the
+ * client makes of them.
+ */
+
+const write = (run: Parameters<typeof MysqlProtocol.encodeWith>[0]): Uint8Array => {
+  const result = MysqlProtocol.encodeWith(run)
+  assert.isTrue(Result.isSuccess(result), "failed to encode test bytes")
+  return (result as Result.Success<Uint8Array, never>).success
+}
+
+const offeredFlags: ReadonlyArray<MysqlProtocol.Capability> = [
+  MysqlProtocol.Capability.protocol41,
+  MysqlProtocol.Capability.pluginAuth,
+  MysqlProtocol.Capability.secureConnection,
+  MysqlProtocol.Capability.deprecateEof,
+  MysqlProtocol.Capability.pluginAuthLenencClientData,
+  MysqlProtocol.Capability.multiStatements,
+  MysqlProtocol.Capability.multiResults,
+  MysqlProtocol.Capability.transactions,
+  MysqlProtocol.Capability.connectWithDb
+]
+
+/** A `HandshakeV10` greeting, minus whichever capabilities a test withholds. */
+const greeting = (options: {
+  readonly without?: ReadonlyArray<MysqlProtocol.Capability> | undefined
+  readonly authPlugin?: string | undefined
+} = {}): Uint8Array => {
+  const without = options.without ?? []
+  const offered = MysqlProtocol.Capabilities.of(offeredFlags.filter((flag) => !without.includes(flag)))
+  const wire = MysqlProtocol.Capabilities.wire(offered)
+  const plugin = options.authPlugin ?? "mysql_native_password"
+  return MysqlProtocol.frame(
+    write((w) => {
+      w.uint8(10)
+      w.cString("8.4.0")
+      w.uint32(42)
+      w.fill(0x61, 8) // scramble head
+      w.uint8(0)
+      w.uint16(wire & 0xffff)
+      w.uint8(MysqlProtocol.defaultCollation)
+      w.uint16(2) // autocommit
+      w.uint16((wire >>> 16) & 0xffff)
+      w.uint8(21) // scramble length
+      w.fill(0, 10)
+      w.fill(0x62, 12)
+      w.uint8(0)
+      w.cString(plugin)
+    }),
+    0
+  )
+}
+
+const okPacket = (sequenceId: number): Uint8Array =>
+  MysqlProtocol.frame(
+    write((w) => {
+      w.uint8(0x00)
+      w.lenencInt(0)
+      w.lenencInt(0)
+      w.uint16(2)
+      w.uint16(0)
+    }),
+    sequenceId
+  )
+
+const errPacket = (sequenceId: number, code: number, state: string, message: string): Uint8Array =>
+  MysqlProtocol.frame(
+    write((w) => {
+      w.uint8(0xff)
+      w.uint16(code)
+      w.utf8("#")
+      w.utf8(state)
+      w.utf8(message)
+    }),
+    sequenceId
+  )
+
+/**
+ * Starts a server that greets each connection and then answers every packet
+ * the client sends with the next entry of `replies`. A reply of `undefined`
+ * means "say nothing", which is how the silent cases are scripted.
+ */
+const withServer = (options: {
+  readonly hello?: Uint8Array | undefined
+  readonly replies: ReadonlyArray<Uint8Array | undefined>
+  readonly onExhausted?: ((socket: Net.Socket) => void) | undefined
+}) =>
+  Effect.acquireRelease(
+    Effect.callback<{ readonly port: number; readonly server: Net.Server }>((resume) => {
+      const server = Net.createServer((socket) => {
+        let index = 0
+        if (options.hello !== undefined) socket.write(options.hello)
+        socket.on("error", () => {})
+        socket.on("data", () => {
+          if (index < options.replies.length) {
+            const reply = options.replies[index++]
+            if (reply !== undefined) socket.write(reply)
+            return
+          }
+          options.onExhausted?.(socket)
+        })
+      })
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address()
+        assert.isTrue(address !== null && typeof address !== "string", "server did not bind")
+        resume(Effect.succeed({ port: (address as Net.AddressInfo).port, server }))
+      })
+    }),
+    ({ server }) =>
+      Effect.callback<void>((resume) => {
+        server.close(() => resume(Effect.void))
+      })
+  )
+
+const connect = (port: number, overrides: Partial<MysqlConnection.Config> = {}) =>
+  MysqlConnection.make({
+    host: "127.0.0.1",
+    port,
+    username: "root",
+    password: undefined,
+    ...overrides
+  })
+
+/** The reply pair a clean session needs: auth OK, then OK for `SET time_zone`. */
+const established = [okPacket(2), okPacket(1)]
+
+describe("MysqlConnection against a scripted server", () => {
+  it.effect("refuses a server that does not offer CLIENT_DEPRECATE_EOF", () =>
+    Effect.gen(function*() {
+      const { port } = yield* withServer({
+        hello: greeting({ without: [MysqlProtocol.Capability.deprecateEof] }),
+        replies: established
+      })
+      const error = yield* Effect.flip(connect(port))
+      assert.include(error.message, "MySQL 8.0 or newer is required")
+      assert.include(String(error.reason.cause), "CLIENT_DEPRECATE_EOF")
+    }).pipe(Effect.scoped))
+
+  it.effect("refuses a server that does not offer CLIENT_PROTOCOL_41", () =>
+    Effect.gen(function*() {
+      const { port } = yield* withServer({
+        hello: greeting({ without: [MysqlProtocol.Capability.protocol41] }),
+        replies: established
+      })
+      const error = yield* Effect.flip(connect(port))
+      assert.include(String(error.reason.cause), "CLIENT_PROTOCOL_41")
+    }).pipe(Effect.scoped))
+
+  it.effect("surfaces an ERR sent in place of a greeting", () =>
+    Effect.gen(function*() {
+      const { port } = yield* withServer({
+        hello: errPacket(0, 1040, "08004", "Too many connections"),
+        replies: []
+      })
+      const error = yield* Effect.flip(connect(port))
+      assert.include(String(error.reason.cause), "Too many connections")
+    }).pipe(Effect.scoped))
+
+  it.effect("fails the connection when authentication is refused", () =>
+    Effect.gen(function*() {
+      const { port } = yield* withServer({
+        hello: greeting(),
+        replies: [errPacket(2, 1045, "28000", "Access denied for user 'root'@'localhost'")]
+      })
+      const error = yield* Effect.flip(connect(port))
+      assert.strictEqual(error.reason._tag, "AuthenticationError")
+      assert.include(String(error.reason.cause), "Access denied")
+    }).pipe(Effect.scoped))
+
+  it.effect("rejects an authentication plugin it does not implement", () =>
+    Effect.gen(function*() {
+      const { port } = yield* withServer({
+        hello: greeting({ authPlugin: "auth_gssapi_client" }),
+        replies: established
+      })
+      const error = yield* Effect.flip(connect(port))
+      assert.include(String(error.reason.cause), "auth_gssapi_client")
+    }).pipe(Effect.scoped))
+
+  it.effect("fails a command whose reply carries the wrong sequence id", () =>
+    Effect.gen(function*() {
+      const { port } = yield* withServer({
+        hello: greeting(),
+        // The reply to a command must start at 1. Answering with 7 is the
+        // desync a real server never produces and the client must not ignore.
+        replies: [...established, okPacket(7)]
+      })
+      const connection = yield* connect(port)
+      const error = yield* Effect.flip(connection.query("SELECT 1"))
+      assert.include(String(error.reason.cause), "sequence id")
+    }).pipe(Effect.scoped))
+
+  it.effect("refuses a LOCAL INFILE request", () =>
+    Effect.gen(function*() {
+      const { port } = yield* withServer({
+        hello: greeting(),
+        // 0xfb opens a LOCAL INFILE request. The capability is never
+        // negotiated, so a server asking for one is in violation.
+        replies: [...established, MysqlProtocol.frame(new Uint8Array([0xfb, 0x61]), 1)]
+      })
+      const connection = yield* connect(port)
+      const error = yield* Effect.flip(connection.query("SELECT 1"))
+      assert.include(error.message, "LOCAL INFILE")
+    }).pipe(Effect.scoped))
+
+  it.effect("fails an in-flight command when the socket closes under it", () =>
+    Effect.gen(function*() {
+      const { port } = yield* withServer({
+        hello: greeting(),
+        replies: established,
+        onExhausted: (socket) => socket.destroy()
+      })
+      const connection = yield* connect(port)
+      const error = yield* Effect.flip(connection.query("SELECT 1"))
+      assert.strictEqual(error.reason._tag, "ConnectionError")
+      // The session is written off rather than left half-read.
+      const next = yield* Effect.flip(connection.query("SELECT 2"))
+      assert.strictEqual(next.reason._tag, "ConnectionError")
+    }).pipe(Effect.scoped))
+
+  it.effect("gives up on a server that accepts the socket and never greets", () =>
+    Effect.gen(function*() {
+      const { port } = yield* withServer({ replies: [] })
+      const fiber = yield* Effect.forkChild(
+        Effect.scoped(Effect.flip(connect(port, { connectTimeout: "2 seconds" })))
+      )
+      yield* TestClock.adjust("2 seconds")
+      const error = yield* Fiber.join(fiber)
+      assert.include(error.message, "Connection timed out")
+    }).pipe(Effect.scoped))
+})

--- a/packages/sql/mysql/test/MysqlConnection.integration.test.ts
+++ b/packages/sql/mysql/test/MysqlConnection.integration.test.ts
@@ -1,0 +1,158 @@
+import { MysqlConnection } from "@effect/sql-mysql"
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as Redacted from "effect/Redacted"
+import { MysqlContainer, okResult, resultSet, rowsOf } from "./utils.ts"
+
+const connect = (overrides: Partial<MysqlConnection.Config> = {}) =>
+  Effect.flatMap(MysqlContainer, (container) =>
+    MysqlConnection.make({
+      url: Redacted.make(container.getConnectionUri()),
+      ...overrides
+    }))
+
+describe("MysqlConnection", () => {
+  it.layer(MysqlContainer.layer, { timeout: "120 seconds" })("against a real server", (it) => {
+    it.effect("completes the handshake", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        assert.isAbove(conn.connectionId, 0)
+        assert.match(conn.serverVersion, /^\d+\.\d+/)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("selects scalars and NULLs", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        const results = yield* conn.query("SELECT 1 AS n, 'hello' AS greeting, NULL AS nothing")
+        assert.strictEqual(results.length, 1)
+        assert.deepStrictEqual(resultSet(results[0]).rows, [{ n: 1n, greeting: "hello", nothing: null }])
+        assert.deepStrictEqual(resultSet(results[0]).columns.map((column) => column.name), ["n", "greeting", "nothing"])
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("reports affected rows and the last insert id", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* conn.query("CREATE TABLE inserts (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(64))")
+        const inserted = yield* conn.query("INSERT INTO inserts (name) VALUES ('alice'), ('bob')")
+        // That an insert returns no rows is the tag's business now, so this
+        // asserts the tag rather than an empty array.
+        assert.strictEqual(inserted[0]._tag, "Ok")
+        assert.strictEqual(okResult(inserted[0]).affectedRows, 2)
+        assert.strictEqual(okResult(inserted[0]).lastInsertId, 1)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("returns one result per statement, which SqlModel depends on", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* conn.query("CREATE TABLE multi (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(64))")
+        const results = yield* conn.query(
+          "INSERT INTO multi (name) VALUES ('carol'); SELECT * FROM multi WHERE id = LAST_INSERT_ID();"
+        )
+        assert.strictEqual(results.length, 2)
+        assert.strictEqual(okResult(results[0]).affectedRows, 1)
+        assert.deepStrictEqual(resultSet(results[1]).rows, [{ id: 1, name: "carol" }])
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("returns rows as arrays", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        const values = yield* conn.queryValues("SELECT 1, 'two'")
+        assert.deepStrictEqual(values, [[1n, "two"]])
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("pings", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* conn.ping
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("connects over TLS", () =>
+      Effect.gen(function*() {
+        // The container serves a self-signed certificate.
+        const conn = yield* connect({ ssl: { rejectUnauthorized: false } })
+        const results = yield* conn.query("SELECT 1 AS n")
+        assert.deepStrictEqual(resultSet(results[0]).rows, [{ n: 1n }])
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("classifies a duplicate key as a unique violation", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* conn.query("CREATE TABLE unique_names (name VARCHAR(64) UNIQUE)")
+        yield* conn.query("INSERT INTO unique_names (name) VALUES ('dave')")
+        const error = yield* Effect.flip(conn.query("INSERT INTO unique_names (name) VALUES ('dave')"))
+        assert.strictEqual(error.reason._tag, "UniqueViolation")
+        assert.strictEqual((error.reason as { readonly constraint: string }).constraint, "unique_names.name")
+        assert.isFalse(error.isRetryable)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("classifies an unknown table as a syntax error", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        const error = yield* Effect.flip(conn.query("SELECT * FROM does_not_exist"))
+        assert.strictEqual(error.reason._tag, "SqlSyntaxError")
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("authenticates a sha256_password account over a plaintext socket", () =>
+      Effect.gen(function*() {
+        const container = yield* MysqlContainer
+        const root = yield* MysqlConnection.make({
+          host: container.getHost(),
+          port: container.getPort(),
+          username: "root",
+          password: Redacted.make(container.getRootPassword()),
+          database: container.getDatabase()
+        })
+        yield* root.query("CREATE USER 'sha_plain'@'%' IDENTIFIED WITH sha256_password BY 'sha-secret'")
+        yield* root.query("GRANT ALL ON *.* TO 'sha_plain'@'%'")
+
+        // sha256_password has no cached verdict, so on a plaintext socket the
+        // client has to fetch the server's key and encrypt the password.
+        const conn = yield* MysqlConnection.make({
+          host: container.getHost(),
+          port: container.getPort(),
+          username: "sha_plain",
+          password: Redacted.make("sha-secret"),
+          database: container.getDatabase()
+        })
+        assert.deepStrictEqual(rowsOf(yield* conn.query("SELECT 1 AS n")), [{ n: 1n }])
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("authenticates a sha256_password account over TLS", () =>
+      Effect.gen(function*() {
+        const container = yield* MysqlContainer
+        const root = yield* MysqlConnection.make({
+          host: container.getHost(),
+          port: container.getPort(),
+          username: "root",
+          password: Redacted.make(container.getRootPassword()),
+          database: container.getDatabase()
+        })
+        yield* root.query("CREATE USER 'sha_tls'@'%' IDENTIFIED WITH sha256_password BY 'sha-secret'")
+        yield* root.query("GRANT ALL ON *.* TO 'sha_tls'@'%'")
+
+        // Over TLS the password goes as it is, with no key exchange.
+        const conn = yield* MysqlConnection.make({
+          host: container.getHost(),
+          port: container.getPort(),
+          username: "sha_tls",
+          password: Redacted.make("sha-secret"),
+          database: container.getDatabase(),
+          ssl: { rejectUnauthorized: false }
+        })
+        assert.deepStrictEqual(rowsOf(yield* conn.query("SELECT 1 AS n")), [{ n: 1n }])
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("rejects a wrong password", () =>
+      Effect.gen(function*() {
+        const container = yield* MysqlContainer
+        const error = yield* Effect.flip(MysqlConnection.make({
+          host: container.getHost(),
+          port: container.getPort(),
+          username: container.getUsername(),
+          password: Redacted.make("definitely-not-the-password"),
+          database: container.getDatabase()
+        }))
+        assert.strictEqual(error.reason._tag, "AuthenticationError")
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+  })
+})

--- a/packages/sql/mysql/test/MysqlPool.integration.test.ts
+++ b/packages/sql/mysql/test/MysqlPool.integration.test.ts
@@ -1,0 +1,112 @@
+import { MysqlPool } from "@effect/sql-mysql"
+import { assert, describe, it } from "@effect/vitest"
+import { Deferred, Effect, Fiber, Redacted } from "effect"
+import { MysqlContainer, resultSet } from "./utils.ts"
+
+const pool = (overrides: Partial<MysqlPool.Config> = {}) =>
+  Effect.flatMap(MysqlContainer, (container) =>
+    MysqlPool.make({
+      url: Redacted.make(container.getConnectionUri()),
+      ...overrides
+    }))
+
+/** The server's own id for a session, which is how we tell them apart. */
+const idOf = (connection: { readonly connectionId: number }) => connection.connectionId
+
+describe("MysqlPool", () => {
+  it.layer(MysqlContainer.layer, { timeout: "120 seconds" })("against a real server", (it) => {
+    it.effect("hands a released session back to the next caller", () =>
+      Effect.gen(function*() {
+        const p = yield* pool({ minConnections: 0, maxConnections: 4 })
+        const first = yield* Effect.scoped(Effect.map(p.get, idOf))
+        const second = yield* Effect.scoped(Effect.map(p.get, idOf))
+        assert.strictEqual(first, second)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("never lends one session to two callers at once", () =>
+      Effect.gen(function*() {
+        const p = yield* pool({ minConnections: 0, maxConnections: 4 })
+        // Held concurrently, so the pool cannot answer both with one session:
+        // MySQL runs one command at a time per connection.
+        const ids = yield* Effect.scoped(Effect.gen(function*() {
+          const a = yield* p.get
+          const b = yield* p.get
+          return [idOf(a), idOf(b)]
+        }))
+        assert.notStrictEqual(ids[0], ids[1])
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("makes a caller wait once maxConnections are out", () =>
+      Effect.gen(function*() {
+        const p = yield* pool({ minConnections: 0, maxConnections: 1 })
+        const release = yield* Deferred.make<void>()
+        const holding = yield* Deferred.make<void>()
+        const holder = yield* Effect.forkChild(Effect.scoped(Effect.gen(function*() {
+          yield* p.get
+          yield* Deferred.succeed(holding, void 0)
+          yield* Deferred.await(release)
+        })))
+        yield* Deferred.await(holding)
+
+        const waiter = yield* Effect.forkChild(Effect.scoped(Effect.map(p.get, idOf)))
+        // The single session is out, so the second checkout cannot be answered
+        // until the first is given back.
+        assert.strictEqual(waiter.pollUnsafe(), undefined)
+        yield* Deferred.succeed(release, void 0)
+        yield* Fiber.join(holder)
+        assert.isNumber(yield* Fiber.join(waiter))
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("replaces a session that has been invalidated", () =>
+      Effect.gen(function*() {
+        const p = yield* pool({ minConnections: 0, maxConnections: 2 })
+        const first = yield* Effect.scoped(Effect.gen(function*() {
+          const connection = yield* p.get
+          yield* p.invalidate(connection)
+          return idOf(connection)
+        }))
+        const second = yield* Effect.scoped(Effect.map(p.get, idOf))
+        assert.notStrictEqual(first, second)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("retires a session after its TTL, so a zero TTL never reuses one", () =>
+      Effect.gen(function*() {
+        const p = yield* pool({ minConnections: 0, maxConnections: 2, connectionTTL: 0 })
+        // Every session is used once and then replaced.
+        const first = yield* Effect.scoped(Effect.map(p.get, idOf))
+        const second = yield* Effect.scoped(Effect.map(p.get, idOf))
+        assert.notStrictEqual(first, second)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("takes a borrowed session back however the effect ends", () =>
+      Effect.gen(function*() {
+        const p = yield* pool({ minConnections: 0, maxConnections: 1 })
+        const borrowed = yield* p.use((connection) => Effect.succeed(idOf(connection)))
+        // A failure must return the session too, or the next borrow deadlocks
+        // against a pool of one.
+        yield* Effect.flip(p.use(() => Effect.fail("nope" as const)))
+        const afterFailure = yield* p.use((connection) => Effect.succeed(idOf(connection)))
+        assert.strictEqual(borrowed, afterFailure)
+        // And so must an interruption.
+        yield* Effect.forkChild(p.use(() => Effect.never)).pipe(Effect.flatMap(Fiber.interrupt))
+        const afterInterrupt = yield* p.use((connection) => Effect.succeed(idOf(connection)))
+        assert.strictEqual(borrowed, afterInterrupt)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("closes every session when the pool's scope closes", () =>
+      Effect.gen(function*() {
+        const probe = yield* pool({ minConnections: 0, maxConnections: 2 })
+        const id = yield* Effect.scoped(Effect.gen(function*() {
+          const p = yield* pool({ minConnections: 0, maxConnections: 2 })
+          return yield* Effect.scoped(Effect.map(p.get, idOf))
+        }))
+        // The server drops a closed session, so its id is gone from the
+        // process list once the pool's scope has closed.
+        const live = yield* Effect.scoped(Effect.flatMap(
+          probe.get,
+          (connection) => connection.query(`SELECT COUNT(*) AS c FROM information_schema.processlist WHERE id = ${id}`)
+        ))
+        assert.strictEqual(resultSet(live[0]).rows[0].c, 0n)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+  })
+})

--- a/packages/sql/mysql/test/MysqlPrepared.integration.test.ts
+++ b/packages/sql/mysql/test/MysqlPrepared.integration.test.ts
@@ -1,0 +1,158 @@
+import { MysqlConnection } from "@effect/sql-mysql"
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as Redacted from "effect/Redacted"
+import { MysqlContainer, resultSet, rowsOf } from "./utils.ts"
+
+const connect = (overrides: Partial<MysqlConnection.Config> = {}) =>
+  Effect.flatMap(MysqlContainer, (container) =>
+    MysqlConnection.make({
+      url: Redacted.make(container.getConnectionUri()),
+      ...overrides
+    }))
+
+/** performance_schema is readable by root but not by the container's test user. */
+const connectAsRoot = (overrides: Partial<MysqlConnection.Config> = {}) =>
+  Effect.flatMap(MysqlContainer, (container) =>
+    MysqlConnection.make({
+      host: container.getHost(),
+      port: container.getPort(),
+      username: "root",
+      password: Redacted.make(container.getRootPassword()),
+      database: container.getDatabase(),
+      ...overrides
+    }))
+
+/**
+ * How many statements this connection holds prepared. Prepared_stmt_count is
+ * global, so it moves as other connections close; performance_schema can be
+ * narrowed to the current session. The query runs on the text protocol, so
+ * asking does not itself prepare anything.
+ */
+const preparedCount = (conn: MysqlConnection.MysqlConnection) =>
+  Effect.map(
+    conn.query(
+      `SELECT COUNT(*) AS n FROM performance_schema.prepared_statements_instances
+       WHERE OWNER_THREAD_ID = (
+         SELECT THREAD_ID FROM performance_schema.threads WHERE PROCESSLIST_ID = CONNECTION_ID()
+       )`
+    ),
+    (results) => Number(resultSet(results[0]).rows[0].n)
+  )
+
+describe("prepared statements", () => {
+  it.layer(MysqlContainer.layer, { timeout: "120 seconds" })("binary protocol", (it) => {
+    it.effect("binds parameters and decodes binary rows", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        const rows = rowsOf(yield* conn.execute("SELECT ? AS a, ? AS b, ? AS c", ["text", 42, null]))
+        assert.deepStrictEqual(rows, [{ a: "text", b: 42n, c: null }])
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("round-trips every parameter kind", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* conn.query(`CREATE TABLE bound (
+          s VARCHAR(64), i INT, b BIGINT, f DOUBLE, t TINYINT, d DATETIME(3), v VARBINARY(8), n INT
+        )`)
+        const when = new Date(Date.UTC(2026, 8, 10, 14, 30, 5, 123))
+        yield* conn.execute("INSERT INTO bound VALUES (?, ?, ?, ?, ?, ?, ?, ?)", [
+          "hello",
+          -7,
+          9007199254740993n,
+          1.5,
+          true,
+          when,
+          new Uint8Array([1, 2, 3]),
+          null
+        ])
+        const rows = rowsOf(yield* conn.execute("SELECT * FROM bound", []))
+        assert.strictEqual(rows[0].s, "hello")
+        assert.strictEqual(rows[0].i, -7)
+        assert.strictEqual(rows[0].b, 9007199254740993n)
+        assert.strictEqual(rows[0].f, 1.5)
+        assert.strictEqual(rows[0].t, 1)
+        assert.strictEqual(rows[0].d, when.getTime())
+        assert.deepStrictEqual(Array.from(rows[0].v as Uint8Array), [1, 2, 3])
+        assert.strictEqual(rows[0].n, null)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("decodes the same values as the text protocol", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* conn.query(`CREATE TABLE parity (
+          i INT, b BIGINT, d DECIMAL(12,4), dt DATETIME, dd DATE, tm TIME, j JSON, t TEXT, bl BLOB
+        )`)
+        yield* conn.query(
+          `INSERT INTO parity VALUES (1, 2, '3.5000', '2026-09-10 14:30:05', '2026-09-10', '-01:00:30',
+           '{"a":1}', 'text', x'DEADBEEF')`
+        )
+        const [text] = yield* conn.query("SELECT * FROM parity")
+        const [binary] = yield* conn.execute("SELECT * FROM parity", [])
+        assert.deepStrictEqual(resultSet(binary).rows, resultSet(text).rows)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("reuses a cached statement instead of preparing it again", () =>
+      Effect.gen(function*() {
+        const conn = yield* connectAsRoot()
+        assert.strictEqual(yield* preparedCount(conn), 0)
+        yield* conn.execute("SELECT 1 AS n", [])
+        assert.strictEqual(yield* preparedCount(conn), 1)
+        yield* conn.execute("SELECT 1 AS n", [])
+        yield* conn.execute("SELECT 1 AS n", [])
+        assert.strictEqual(yield* preparedCount(conn), 1)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("closes an evicted statement rather than leaking it", () =>
+      Effect.gen(function*() {
+        const conn = yield* connectAsRoot({ preparedStatementCacheSize: 2 })
+        yield* conn.execute("SELECT 1 AS a", [])
+        yield* conn.execute("SELECT 2 AS b", [])
+        assert.strictEqual(yield* preparedCount(conn), 2)
+        // The third prepare evicts the first, whose COM_STMT_CLOSE rides along
+        // with the next request rather than costing its own round trip.
+        yield* conn.execute("SELECT 3 AS c", [])
+        yield* conn.execute("SELECT 3 AS c", [])
+        assert.strictEqual(yield* preparedCount(conn), 2)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("re-prepares a statement that was evicted", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect({ preparedStatementCacheSize: 1 })
+        assert.deepStrictEqual(rowsOf(yield* conn.execute("SELECT 1 AS n", [])), [{ n: 1n }])
+        assert.deepStrictEqual(rowsOf(yield* conn.execute("SELECT 2 AS n", [])), [{ n: 2n }])
+        assert.deepStrictEqual(rowsOf(yield* conn.execute("SELECT 1 AS n", [])), [{ n: 1n }])
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("prepares nothing when preparation is disabled", () =>
+      Effect.gen(function*() {
+        const conn = yield* connectAsRoot({ prepare: false })
+        const rows = rowsOf(yield* conn.query("SELECT 1 AS n"))
+        assert.deepStrictEqual(rows, [{ n: 1n }])
+        assert.strictEqual(yield* preparedCount(conn), 0)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("reports a parameter count mismatch", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        const error = yield* Effect.flip(conn.execute("SELECT ?, ?", [1]))
+        assert.match(error.message, /parameter/i)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("classifies an error from a prepared statement", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* conn.query("CREATE TABLE prepared_unique (name VARCHAR(64) UNIQUE)")
+        yield* conn.execute("INSERT INTO prepared_unique (name) VALUES (?)", ["x"])
+        const error = yield* Effect.flip(conn.execute("INSERT INTO prepared_unique (name) VALUES (?)", ["x"]))
+        assert.strictEqual(error.reason._tag, "UniqueViolation")
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("reports a syntax error at prepare time", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        const error = yield* Effect.flip(conn.execute("SELECT * FROM no_such_table_here", []))
+        assert.strictEqual(error.reason._tag, "SqlSyntaxError")
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+  })
+})

--- a/packages/sql/mysql/test/MysqlProtocol.test.ts
+++ b/packages/sql/mysql/test/MysqlProtocol.test.ts
@@ -1,0 +1,435 @@
+import { MysqlProtocol } from "@effect/sql-mysql"
+import { assert, describe, it } from "@effect/vitest"
+import * as Result from "effect/Result"
+
+const hex = (value: Uint8Array): string => Array.from(value, (byte) => byte.toString(16).padStart(2, "0")).join("")
+
+const bytes = (value: string): Uint8Array => {
+  const out = new Uint8Array(value.length / 2)
+  for (let index = 0; index < out.length; index++) {
+    out[index] = Number.parseInt(value.slice(index * 2, index * 2 + 2), 16)
+  }
+  return out
+}
+
+const success = <A, E>(result: Result.Result<A, E>): A => {
+  assert.isTrue(Result.isSuccess(result), "expected a success")
+  return (result as Result.Success<A, E>).success
+}
+
+const failure = <A, E>(result: Result.Result<A, E>): E => {
+  assert.isTrue(Result.isFailure(result), "expected a failure")
+  return (result as Result.Failure<A, E>).failure
+}
+
+const write = (
+  run: Parameters<typeof MysqlProtocol.encodeWith>[0]
+): Uint8Array => success(MysqlProtocol.encodeWith(run))
+
+const assertThrowsTagged = (tag: string, run: () => unknown): void => {
+  try {
+    run()
+  } catch (error) {
+    assert.strictEqual((error as { readonly _tag?: string })._tag, tag)
+    return
+  }
+  assert.fail(`Expected ${tag}`)
+}
+
+describe("MysqlProtocol", () => {
+  describe("framing", () => {
+    it("writes a three-byte little-endian length and a sequence id", () => {
+      assert.strictEqual(hex(MysqlProtocol.frame(bytes("aabbcc"), 7)), "03000007aabbcc")
+    })
+
+    it("frames an empty payload", () => {
+      assert.strictEqual(hex(MysqlProtocol.frame(new Uint8Array(0), 0)), "00000000")
+    })
+
+    it("round-trips a payload through the parser", () => {
+      const parser = MysqlProtocol.makeParser()
+      const packets = parser.push(MysqlProtocol.frame(bytes("0102030405"), 0))
+      assert.strictEqual(packets.length, 1)
+      assert.strictEqual(packets[0].sequenceId, 0)
+      assert.strictEqual(hex(packets[0].payload), "0102030405")
+    })
+
+    it("reads several packets from one chunk", () => {
+      const parser = MysqlProtocol.makeParser()
+      const chunk = new Uint8Array([
+        ...MysqlProtocol.frame(bytes("aa"), 0),
+        ...MysqlProtocol.frame(bytes("bbbb"), 1),
+        ...MysqlProtocol.frame(bytes("cc"), 2)
+      ])
+      const packets = parser.push(chunk)
+      assert.deepStrictEqual(packets.map((packet) => hex(packet.payload)), ["aa", "bbbb", "cc"])
+      assert.deepStrictEqual(packets.map((packet) => packet.sequenceId), [0, 1, 2])
+    })
+
+    it("reassembles a packet fed one byte at a time", () => {
+      const parser = MysqlProtocol.makeParser()
+      const framed = MysqlProtocol.frame(bytes("deadbeefcafe"), 0)
+      const seen: Array<string> = []
+      for (const byte of framed) {
+        for (const packet of parser.push(new Uint8Array([byte]))) seen.push(hex(packet.payload))
+      }
+      assert.deepStrictEqual(seen, ["deadbeefcafe"])
+    })
+
+    it("holds back a partial packet", () => {
+      const parser = MysqlProtocol.makeParser()
+      const framed = MysqlProtocol.frame(bytes("0102030405"), 0)
+      assert.strictEqual(parser.push(framed.subarray(0, 6)).length, 0)
+      const packets = parser.push(framed.subarray(6))
+      assert.strictEqual(packets.length, 1)
+      assert.strictEqual(hex(packets[0].payload), "0102030405")
+    })
+
+    it("rejects an out-of-order sequence id", () => {
+      const parser = MysqlProtocol.makeParser()
+      assertThrowsTagged(
+        "MysqlProtocolParseError",
+        () => parser.push(MysqlProtocol.frame(bytes("aa"), 3))
+      )
+    })
+
+    it("starts from an explicit sequence id", () => {
+      const parser = MysqlProtocol.makeParser({ expectedSequenceId: 1 })
+      const packets = parser.push(MysqlProtocol.frame(bytes("aa"), 1))
+      assert.strictEqual(packets.length, 1)
+      assert.strictEqual(parser.expectedSequenceId, 2)
+    })
+
+    it("wraps the sequence id at 256", () => {
+      const parser = MysqlProtocol.makeParser({ expectedSequenceId: 255 })
+      parser.push(MysqlProtocol.frame(bytes("aa"), 255))
+      assert.strictEqual(parser.expectedSequenceId, 0)
+    })
+
+    it("cannot be reused after a failure", () => {
+      const parser = MysqlProtocol.makeParser()
+      assertThrowsTagged("MysqlProtocolParseError", () => parser.push(MysqlProtocol.frame(bytes("aa"), 9)))
+      assertThrowsTagged("MysqlProtocolParseError", () => parser.push(MysqlProtocol.frame(bytes("aa"), 0)))
+    })
+
+    it("splits and rejoins a payload of exactly the maximum size", () => {
+      const payload = new Uint8Array(MysqlProtocol.maxPacketPayload)
+      payload[0] = 0x41
+      payload[payload.length - 1] = 0x5a
+      const framed = MysqlProtocol.frame(payload, 0)
+      // One full packet plus an empty terminator, so the server can tell a split
+      // message from a complete one.
+      assert.strictEqual(framed.length, MysqlProtocol.maxPacketPayload + MysqlProtocol.packetHeaderSize * 2)
+      const packets = MysqlProtocol.makeParser().push(framed)
+      assert.strictEqual(packets.length, 1)
+      assert.strictEqual(packets[0].payload.length, MysqlProtocol.maxPacketPayload)
+      assert.strictEqual(packets[0].payload[0], 0x41)
+      assert.strictEqual(packets[0].payload[packets[0].payload.length - 1], 0x5a)
+    })
+
+    it("rejoins a payload that straddles the maximum size", () => {
+      const payload = new Uint8Array(MysqlProtocol.maxPacketPayload + 5)
+      payload.fill(0x2a)
+      payload[payload.length - 1] = 0x7f
+      const packets = MysqlProtocol.makeParser().push(MysqlProtocol.frame(payload, 0))
+      assert.strictEqual(packets.length, 1)
+      assert.strictEqual(packets[0].payload.length, payload.length)
+      assert.strictEqual(packets[0].payload[payload.length - 1], 0x7f)
+    })
+
+    it("refuses a joined message above maxMessageSize", () => {
+      const payload = new Uint8Array(MysqlProtocol.maxPacketPayload + 1)
+      const parser = MysqlProtocol.makeParser({ maxMessageSize: 1024 })
+      assertThrowsTagged("MysqlProtocolParseError", () => parser.push(MysqlProtocol.frame(payload, 0)))
+    })
+  })
+
+  describe("length-encoded values", () => {
+    it("writes each integer width", () => {
+      assert.strictEqual(hex(write((w) => w.lenencInt(250))), "fa")
+      assert.strictEqual(hex(write((w) => w.lenencInt(251))), "fcfb00")
+      assert.strictEqual(hex(write((w) => w.lenencInt(0xffff))), "fcffff")
+      assert.strictEqual(hex(write((w) => w.lenencInt(0x10000))), "fd000001")
+      assert.strictEqual(hex(write((w) => w.lenencInt(0xffffff))), "fdffffff")
+      assert.strictEqual(hex(write((w) => w.lenencInt(0x1000000))), "fe0000000100000000")
+    })
+
+    it("keeps precision above the safe integer range", () => {
+      const value = 2n ** 63n + 1n
+      assert.strictEqual(hex(write((w) => w.lenencInt(value))), "fe0100000000000080")
+    })
+
+    it("refuses a negative length", () => {
+      assert.strictEqual(failure(MysqlProtocol.encodeWith((w) => w.lenencInt(-1)))._tag, "MysqlProtocolEncodeError")
+    })
+
+    it("writes a length-encoded string by byte length, not code units", () => {
+      assert.strictEqual(hex(write((w) => w.lenencString("é"))), "02c3a9")
+    })
+  })
+
+  describe("decodeResponse", () => {
+    it("reads an OK packet", () => {
+      const response = success(MysqlProtocol.decodeResponse(bytes("00010302000000")))
+      assert.strictEqual(response._tag, "Ok")
+      if (response._tag === "Ok") assert.strictEqual(response.ok.affectedRows, 1)
+    })
+
+    it("reads an ERR packet", () => {
+      const response = success(MysqlProtocol.decodeResponse(bytes("ff1504")))
+      assert.strictEqual(response._tag, "Error")
+    })
+
+    it("reads a result-set header and its column count", () => {
+      const response = success(MysqlProtocol.decodeResponse(bytes("03")))
+      assert.strictEqual(response._tag, "ResultSet")
+      if (response._tag === "ResultSet") assert.strictEqual(response.columnCount, 3)
+    })
+
+    it("reads a LOCAL INFILE request, which is only meaningful here", () => {
+      assert.strictEqual(success(MysqlProtocol.decodeResponse(bytes("fb2f746d702f78")))._tag, "LocalInfile")
+    })
+
+    it("reads the short 0xfe packet as an OK", () => {
+      assert.strictEqual(success(MysqlProtocol.decodeResponse(bytes("fe000002000000")))._tag, "Ok")
+    })
+  })
+
+  describe("decodeRow", () => {
+    it("reads a row", () => {
+      const row = success(MysqlProtocol.decodeRow(write((w) => w.lenencString("alice"))))
+      assert.strictEqual(row._tag, "Row")
+    })
+
+    it("reads a row whose first column is an empty string, not an OK packet", () => {
+      // 0x00 followed by enough bytes to look like an OK packet in the
+      // response position.
+      const payload = write((w) => {
+        w.lenencString("")
+        w.lenencString("aaaaaaaa")
+      })
+      assert.isAtLeast(payload.length, 7)
+      assert.strictEqual(success(MysqlProtocol.decodeRow(payload))._tag, "Row")
+    })
+
+    it("reads a row whose first column is NULL, not a LOCAL INFILE request", () => {
+      const payload = write((w) => {
+        w.uint8(0xfb)
+        w.lenencString("value")
+      })
+      assert.strictEqual(success(MysqlProtocol.decodeRow(payload))._tag, "Row")
+    })
+
+    it("reads the terminator", () => {
+      const end = success(MysqlProtocol.decodeRow(bytes("fe000002000000")))
+      assert.strictEqual(end._tag, "End")
+      if (end._tag === "End") {
+        assert.isTrue(
+          MysqlProtocol.ServerStatus.has(end.ok.statusFlags, MysqlProtocol.ServerStatusFlag.autocommit)
+        )
+      }
+    })
+
+    it("reads an error", () => {
+      assert.strictEqual(success(MysqlProtocol.decodeRow(bytes("ff1504")))._tag, "Error")
+    })
+
+    it("treats a long 0xfe payload as a row, because 0xfe also prefixes a length", () => {
+      assert.strictEqual(success(MysqlProtocol.decodeRow(bytes("fe00000000000000ff")))._tag, "Row")
+    })
+  })
+
+  describe("decoding", () => {
+    it("decodes an OK packet", () => {
+      const ok = success(MysqlProtocol.decodeOk(bytes("00010302000000")))
+      assert.strictEqual(ok.affectedRows, 1)
+      assert.strictEqual(ok.lastInsertId, 3)
+      assert.strictEqual(ok.statusFlags, 2)
+      assert.strictEqual(ok.warnings, 0)
+      assert.strictEqual(ok.info, "")
+    })
+
+    it("decodes the 0xfe OK packet that replaces EOF", () => {
+      const ok = success(MysqlProtocol.decodeOk(bytes("fe000002000000")))
+      assert.strictEqual(ok.affectedRows, 0)
+      assert.strictEqual(ok.statusFlags, 2)
+    })
+
+    it("decodes trailing info", () => {
+      const payload = write((w) => {
+        w.uint8(0x00)
+        w.lenencInt(0)
+        w.lenencInt(0)
+        w.uint16(2)
+        w.uint16(0)
+        w.utf8("Records: 3")
+      })
+      assert.strictEqual(success(MysqlProtocol.decodeOk(payload)).info, "Records: 3")
+    })
+
+    it("decodes an ERR packet with a SQL state", () => {
+      const payload = write((w) => {
+        w.uint8(0xff)
+        w.uint16(1062)
+        w.uint8(0x23)
+        w.utf8("23000")
+        w.utf8("Duplicate entry 'a' for key 'users.email'")
+      })
+      const err = success(MysqlProtocol.decodeErr(payload))
+      assert.strictEqual(err.code, 1062)
+      assert.strictEqual(err.sqlState, "23000")
+      assert.strictEqual(err.message, "Duplicate entry 'a' for key 'users.email'")
+    })
+
+    it("decodes an ERR packet sent before capabilities are agreed", () => {
+      const payload = write((w) => {
+        w.uint8(0xff)
+        w.uint16(1040)
+        w.utf8("Too many connections")
+      })
+      const err = success(MysqlProtocol.decodeErr(payload))
+      assert.strictEqual(err.code, 1040)
+      assert.strictEqual(err.sqlState, undefined)
+      assert.strictEqual(err.message, "Too many connections")
+    })
+
+    it("decodes a legacy EOF packet", () => {
+      const eof = success(MysqlProtocol.decodeEof(bytes("fe00000200")))
+      assert.strictEqual(eof.warnings, 0)
+      assert.strictEqual(eof.statusFlags, 2)
+    })
+
+    it("decodes a column definition", () => {
+      const payload = write((w) => {
+        w.lenencString("def")
+        w.lenencString("effect")
+        w.lenencString("users")
+        w.lenencString("users")
+        w.lenencString("email")
+        w.lenencString("email")
+        w.lenencInt(0x0c)
+        w.uint16(MysqlProtocol.defaultCollation)
+        w.uint32(1020)
+        w.uint8(MysqlProtocol.ColumnType.varString)
+        w.uint16(MysqlProtocol.ColumnFlag.notNull)
+        w.uint8(0)
+        w.fill(0, 2)
+      })
+      const column = success(MysqlProtocol.decodeColumn(payload))
+      assert.strictEqual(column.schema, "effect")
+      assert.strictEqual(column.table, "users")
+      assert.strictEqual(column.name, "email")
+      assert.strictEqual(column.type, MysqlProtocol.ColumnType.varString)
+      assert.strictEqual(column.columnLength, 1020)
+      assert.isTrue(MysqlProtocol.ColumnFlags.has(column.flags, MysqlProtocol.ColumnFlag.notNull))
+    })
+  })
+
+  describe("decodeTextRow", () => {
+    const row = (payload: Uint8Array, columns: number) =>
+      MysqlProtocol.decodeTextRow(payload, columns, MysqlProtocol.readFieldString)
+
+    it("decodes fields and NULLs", () => {
+      const payload = write((w) => {
+        w.lenencString("alice")
+        w.uint8(0xfb)
+        w.lenencString("30")
+      })
+      assert.deepStrictEqual(success(row(payload, 3)), ["alice", null, "30"])
+    })
+
+    it("decodes a field longer than 250 bytes", () => {
+      const long = "x".repeat(300)
+      const payload = write((w) => w.lenencString(long))
+      assert.deepStrictEqual(success(row(payload, 1)), [long])
+    })
+
+    it("decodes an empty field", () => {
+      const payload = write((w) => w.lenencString(""))
+      assert.deepStrictEqual(success(row(payload, 1)), [""])
+    })
+
+    it("fails when a field claims more bytes than the row holds", () => {
+      assert.strictEqual(failure(row(bytes("0561626364"), 1))._tag, "MysqlProtocolParseError")
+    })
+
+    it("fails when the row has trailing bytes", () => {
+      const payload = write((w) => {
+        w.lenencString("a")
+        w.lenencString("b")
+      })
+      assert.strictEqual(failure(row(payload, 1))._tag, "MysqlProtocolParseError")
+    })
+
+    it("fails when the row runs out of columns", () => {
+      const payload = write((w) => w.lenencString("a"))
+      assert.strictEqual(failure(row(payload, 2))._tag, "MysqlProtocolParseError")
+    })
+
+    it("hands out byte views with the default reader", () => {
+      const payload = write((w) => {
+        w.lenencString("hi")
+        w.uint8(0xfb)
+      })
+      const decoded = success(MysqlProtocol.decodeTextRow(payload, 2, MysqlProtocol.readFieldBytes))
+      assert.strictEqual(hex(decoded[0]!), "6869")
+      assert.strictEqual(decoded[1], null)
+    })
+  })
+
+  describe("commands", () => {
+    it("frames COM_QUERY at sequence id zero", () => {
+      assert.strictEqual(hex(MysqlProtocol.encodeQuery("SELECT 1")), "090000000353454c4543542031")
+    })
+
+    it("frames COM_PING and COM_QUIT", () => {
+      assert.strictEqual(hex(MysqlProtocol.encodePing()), "010000000e")
+      assert.strictEqual(hex(MysqlProtocol.encodeQuit()), "0100000001")
+    })
+
+    it("frames COM_INIT_DB", () => {
+      assert.strictEqual(hex(MysqlProtocol.encodeInitDb("effect")), "0700000002656666656374")
+    })
+  })
+
+  describe("Capabilities", () => {
+    it("reads flags above the signed 32-bit range", () => {
+      const capabilities = MysqlProtocol.Capabilities.of([
+        MysqlProtocol.Capability.protocol41,
+        MysqlProtocol.Capability.sslVerifyServerCert
+      ])
+      assert.isTrue(MysqlProtocol.Capabilities.has(capabilities, MysqlProtocol.Capability.sslVerifyServerCert))
+      assert.isTrue(MysqlProtocol.Capabilities.has(capabilities, MysqlProtocol.Capability.protocol41))
+      assert.isFalse(MysqlProtocol.Capabilities.has(capabilities, MysqlProtocol.Capability.deprecateEof))
+    })
+
+    it("rebuilds the set from the two halves the handshake sends", () => {
+      const capabilities = MysqlProtocol.Capabilities.fromHalves(
+        MysqlProtocol.Capability.protocol41,
+        MysqlProtocol.Capability.deprecateEof / 0x10000
+      )
+      assert.isTrue(MysqlProtocol.Capabilities.has(capabilities, MysqlProtocol.Capability.protocol41))
+      assert.isTrue(MysqlProtocol.Capabilities.has(capabilities, MysqlProtocol.Capability.deprecateEof))
+    })
+
+    it("keeps only the flags both sides offer", () => {
+      const server = MysqlProtocol.Capabilities.of([
+        MysqlProtocol.Capability.protocol41,
+        MysqlProtocol.Capability.compress
+      ])
+      const wanted = [MysqlProtocol.Capability.protocol41, MysqlProtocol.Capability.deprecateEof]
+      const agreed = MysqlProtocol.Capabilities.retain(server, wanted)
+      assert.isTrue(MysqlProtocol.Capabilities.has(agreed, MysqlProtocol.Capability.protocol41))
+      assert.isFalse(MysqlProtocol.Capabilities.has(agreed, MysqlProtocol.Capability.deprecateEof))
+      assert.isFalse(MysqlProtocol.Capabilities.has(agreed, MysqlProtocol.Capability.compress))
+    })
+
+    it("reduces to 32 bits on the wire", () => {
+      const all = MysqlProtocol.Capabilities.of([
+        MysqlProtocol.Capability.protocol41,
+        MysqlProtocol.Capability.rememberOptions
+      ])
+      assert.strictEqual(MysqlProtocol.Capabilities.wire(all), 2 ** 9 + 2 ** 31)
+    })
+  })
+})

--- a/packages/sql/mysql/test/MysqlStream.integration.test.ts
+++ b/packages/sql/mysql/test/MysqlStream.integration.test.ts
@@ -1,0 +1,133 @@
+import { MysqlConnection } from "@effect/sql-mysql"
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as Option from "effect/Option"
+import * as Redacted from "effect/Redacted"
+import * as Stream from "effect/Stream"
+import * as TestClock from "effect/testing/TestClock"
+import { SqlClient } from "effect/unstable/sql"
+import { MysqlContainer, rowsOf } from "./utils.ts"
+
+const connect = (overrides: Partial<MysqlConnection.Config> = {}) =>
+  Effect.flatMap(MysqlContainer, (container) =>
+    MysqlConnection.make({
+      url: Redacted.make(container.getConnectionUri()),
+      ...overrides
+    }))
+
+/** Fills a table with `count` rows, using a recursive CTE rather than a loop. */
+const seed = (conn: MysqlConnection.MysqlConnection, table: string, count: number) =>
+  Effect.gen(function*() {
+    yield* conn.query(`CREATE TABLE ${table} (n INT)`)
+    yield* conn.query(`SET SESSION cte_max_recursion_depth = ${count + 1}`)
+    yield* conn.query(
+      `INSERT INTO ${table} (n) WITH RECURSIVE seq(x) AS (
+         SELECT 1 UNION ALL SELECT x + 1 FROM seq WHERE x < ${count}
+       ) SELECT x FROM seq`
+    )
+  })
+
+describe("streaming", () => {
+  it.layer(MysqlContainer.layer, { timeout: "120 seconds" })("against a real server", (it) => {
+    it.effect("emits the same rows execute returns", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* seed(conn, "stream_parity", 500)
+        const streamed = yield* Stream.runCollect(conn.stream("SELECT n FROM stream_parity ORDER BY n", []))
+        const rows = rowsOf(yield* conn.execute("SELECT n FROM stream_parity ORDER BY n", []))
+        assert.strictEqual(streamed.length, 500)
+        assert.deepStrictEqual(Array.from(streamed), Array.from(rows))
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("applies backpressure across many rows", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* seed(conn, "stream_many", 2000)
+        // The queue holds 128 rows, so a result this size pauses and resumes
+        // the socket repeatedly rather than buffering everything.
+        const total = yield* Stream.runFold(
+          conn.stream("SELECT n FROM stream_many ORDER BY n", []),
+          () => 0,
+          (sum, row) => sum + Number(row.n)
+        )
+        assert.strictEqual(total, (2000 * 2001) / 2)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("leaves the session usable after a stream is abandoned", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* seed(conn, "stream_abandon", 2000)
+        // Taking one row closes the stream's scope with most of the result set
+        // still in flight, which has to be cancelled and drained.
+        const head = yield* Stream.runHead(conn.stream("SELECT n FROM stream_abandon ORDER BY n", []))
+        assert.deepStrictEqual(head, Option.some({ n: 1 }))
+
+        // The session must be clean enough for the next command.
+        const rows = rowsOf(yield* conn.query("SELECT COUNT(*) AS c FROM stream_abandon"))
+        assert.strictEqual(rows[0].c, 2000n)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    // The test above reaches the abandoned-stream drain, but only reaches the
+    // hard case by luck. Two things have to line up. The consumer has to stall
+    // long enough for the producer to fill the stream's queue, which pauses the
+    // socket and — since nothing drains that queue — never resumes it. And the
+    // reply has to be too large to be sitting in the parser's buffer already,
+    // or the drain finds its terminator without reading the socket at all and
+    // the pause goes unnoticed. Padding the rows out to roughly 4MB is what
+    // makes it certain: at this size the drain has to lift the pause itself.
+    it.effect("drains an abandoned stream that backpressure left paused", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* seed(conn, "stream_paused", 20_000)
+        // `withLive` because `it.layer` installs a `TestClock`, under which the
+        // sleep would never elapse and the test would hang whether or not the
+        // drain works.
+        const head = yield* conn.stream(
+          "SELECT n, RPAD('x', 200, 'x') AS p FROM stream_paused ORDER BY n",
+          []
+        ).pipe(
+          Stream.tap(() => Effect.sleep("250 millis")),
+          Stream.runHead,
+          TestClock.withLive
+        )
+        assert.deepStrictEqual(Option.map(head, (row) => row.n), Option.some(1))
+
+        // The session must be clean enough for the next command.
+        const rows = rowsOf(yield* conn.query("SELECT COUNT(*) AS c FROM stream_paused"))
+        assert.strictEqual(rows[0].c, 20_000n)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("streams over the text protocol when preparation is disabled", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect({ prepare: false })
+        yield* seed(conn, "stream_text", 300)
+        const streamed = yield* Stream.runCollect(conn.stream("SELECT n FROM stream_text WHERE n > ?", [297]))
+        assert.deepStrictEqual(Array.from(streamed), [{ n: 298 }, { n: 299 }, { n: 300 }])
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("fails the stream on a server error", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        const error = yield* Effect.flip(Stream.runCollect(conn.stream("SELECT * FROM no_stream_table", [])))
+        assert.strictEqual(error.reason._tag, "SqlSyntaxError")
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("streams through the client", () =>
+      Effect.gen(function*() {
+        const sql = yield* SqlClient.SqlClient
+        yield* sql`CREATE TABLE client_stream (n INT)`
+        yield* sql`INSERT INTO client_stream ${sql.insert([{ n: 1 }, { n: 2 }, { n: 3 }])}`
+        const rows = yield* Stream.runCollect(sql`SELECT n FROM client_stream ORDER BY n`.stream)
+        assert.deepStrictEqual(Array.from(rows), [{ n: 1 }, { n: 2 }, { n: 3 }])
+      }).pipe(Effect.provide(MysqlContainer.client)), { timeout: 60_000 })
+
+    it.effect("applies result transforms to streamed rows", () =>
+      Effect.gen(function*() {
+        const sql = yield* SqlClient.SqlClient
+        yield* sql`CREATE TABLE stream_transform (user_id INT)`
+        yield* sql`INSERT INTO stream_transform ${sql.insert([{ userId: 1 }, { userId: 2 }])}`
+        const rows = yield* Stream.runCollect(sql`SELECT * FROM stream_transform ORDER BY user_id`.stream)
+        assert.deepStrictEqual(Array.from(rows), [{ userId: 1 }, { userId: 2 }])
+      }).pipe(Effect.provide(MysqlContainer.clientWithTransforms)), { timeout: 60_000 })
+  })
+})

--- a/packages/sql/mysql/test/MysqlTypes.integration.test.ts
+++ b/packages/sql/mysql/test/MysqlTypes.integration.test.ts
@@ -1,0 +1,207 @@
+import { MysqlConnection } from "@effect/sql-mysql"
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as Redacted from "effect/Redacted"
+import { MysqlContainer, resultSet, rowsOf } from "./utils.ts"
+
+const connect = (overrides: Partial<MysqlConnection.Config> = {}) =>
+  Effect.flatMap(MysqlContainer, (container) =>
+    MysqlConnection.make({
+      url: Redacted.make(container.getConnectionUri()),
+      ...overrides
+    }))
+
+/** Reads one expression back through the text protocol. */
+const scalar = (expression: string, overrides: Partial<MysqlConnection.Config> = {}) =>
+  Effect.gen(function*() {
+    const conn = yield* connect(overrides)
+    const results = yield* conn.query(`SELECT ${expression} AS value`)
+    return resultSet(results[0]).rows[0].value
+  }).pipe(Effect.scoped)
+
+describe("MysqlTypes", () => {
+  it.layer(MysqlContainer.layer, { timeout: "120 seconds" })("text protocol", (it) => {
+    it.effect("decodes integers as numbers and BIGINT as bigint", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* conn.query(`CREATE TABLE ints (
+          t TINYINT, s SMALLINT, m MEDIUMINT, i INT, b BIGINT, u BIGINT UNSIGNED, y YEAR
+        )`)
+        yield* conn.query(
+          "INSERT INTO ints VALUES (-8, -300, -70000, -2147483648, -9223372036854775808, 18446744073709551615, 2026)"
+        )
+        const rows = rowsOf(yield* conn.query("SELECT * FROM ints"))
+        assert.deepStrictEqual(rows[0], {
+          t: -8,
+          s: -300,
+          m: -70000,
+          i: -2147483648,
+          b: -9223372036854775808n,
+          u: 18446744073709551615n,
+          y: 2026
+        })
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("decodes BIGINT as a number when asked", () =>
+      Effect.gen(function*() {
+        assert.strictEqual(yield* scalar("CAST(42 AS SIGNED)", { bigintAsNumber: true }), 42)
+      }), { timeout: 60_000 })
+
+    it.effect("keeps DECIMAL exact by decoding it as a string", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* conn.query("CREATE TABLE money (amount DECIMAL(20, 4))")
+        yield* conn.query("INSERT INTO money VALUES ('12345678901234.5678')")
+        const rows = rowsOf(yield* conn.query("SELECT * FROM money"))
+        assert.strictEqual(rows[0].amount, "12345678901234.5678")
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("decodes floating point as numbers", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* conn.query("CREATE TABLE floats (f FLOAT, d DOUBLE)")
+        yield* conn.query("INSERT INTO floats VALUES (1.5, -2.25e10)")
+        const rows = rowsOf(yield* conn.query("SELECT * FROM floats"))
+        assert.strictEqual(rows[0].f, 1.5)
+        assert.strictEqual(rows[0].d, -22500000000)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("decodes DATE as a string and DATETIME as epoch milliseconds", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* conn.query("CREATE TABLE times (d DATE, dt DATETIME(6), ts TIMESTAMP)")
+        yield* conn.query(
+          "INSERT INTO times VALUES ('2026-09-10', '2026-09-10 14:30:05.123456', '2026-09-10 14:30:05')"
+        )
+        const rows = rowsOf(yield* conn.query("SELECT * FROM times"))
+        assert.strictEqual(rows[0].d, "2026-09-10")
+        assert.strictEqual(rows[0].dt, Date.UTC(2026, 8, 10, 14, 30, 5, 123))
+        assert.strictEqual(rows[0].ts, Date.UTC(2026, 8, 10, 14, 30, 5))
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("decodes temporal columns as strings when asked", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect({ dateStrings: true })
+        yield* conn.query("CREATE TABLE stringy (dt DATETIME)")
+        yield* conn.query("INSERT INTO stringy VALUES ('2026-09-10 14:30:05')")
+        const rows = rowsOf(yield* conn.query("SELECT * FROM stringy"))
+        assert.strictEqual(rows[0].dt, "2026-09-10 14:30:05")
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("decodes TIME as signed microseconds, since it is a duration", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* conn.query("CREATE TABLE durations (a TIME(6), b TIME)")
+        yield* conn.query("INSERT INTO durations VALUES ('838:59:59.000000', '-01:00:30')")
+        const rows = rowsOf(yield* conn.query("SELECT * FROM durations"))
+        assert.strictEqual(rows[0].a, 838n * 3_600_000_000n + 59n * 60_000_000n + 59n * 1_000_000n)
+        assert.strictEqual(rows[0].b, -(3_600_000_000n + 30_000_000n))
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("tells BLOB from TEXT by the binary collation", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* conn.query("CREATE TABLE blobs (t TEXT, b BLOB, v VARBINARY(16), c VARCHAR(16))")
+        yield* conn.query("INSERT INTO blobs VALUES ('text', x'DEADBEEF', x'0102', 'chars')")
+        const rows = rowsOf(yield* conn.query("SELECT * FROM blobs"))
+        assert.strictEqual(rows[0].t, "text")
+        assert.strictEqual(rows[0].c, "chars")
+        assert.instanceOf(rows[0].b, Uint8Array)
+        assert.deepStrictEqual(Array.from(rows[0].b as Uint8Array), [0xde, 0xad, 0xbe, 0xef])
+        assert.deepStrictEqual(Array.from(rows[0].v as Uint8Array), [0x01, 0x02])
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("parses JSON columns", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* conn.query("CREATE TABLE docs (body JSON)")
+        yield* conn.query(`INSERT INTO docs VALUES ('{"a":[1,2],"b":"x"}')`)
+        const rows = rowsOf(yield* conn.query("SELECT * FROM docs"))
+        assert.deepStrictEqual(rows[0].body, { a: [1, 2], b: "x" })
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("decodes BIT as a bigint", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* conn.query("CREATE TABLE flags (a BIT(1), b BIT(16))")
+        yield* conn.query("INSERT INTO flags VALUES (b'1', b'1000000010000001')")
+        const rows = rowsOf(yield* conn.query("SELECT * FROM flags"))
+        assert.strictEqual(rows[0].a, 1n)
+        assert.strictEqual(rows[0].b, 0b1000000010000001n)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("decodes ENUM and SET as strings", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* conn.query("CREATE TABLE choices (e ENUM('a','b'), s SET('x','y'))")
+        yield* conn.query("INSERT INTO choices VALUES ('b', 'x,y')")
+        const rows = rowsOf(yield* conn.query("SELECT * FROM choices"))
+        assert.strictEqual(rows[0].e, "b")
+        assert.strictEqual(rows[0].s, "x,y")
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("round-trips multi-byte text", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* conn.query("CREATE TABLE unicode (v VARCHAR(64)) CHARACTER SET utf8mb4")
+        yield* conn.query("INSERT INTO unicode VALUES ('héllo 🌍 日本語')")
+        const rows = rowsOf(yield* conn.query("SELECT * FROM unicode"))
+        assert.strictEqual(rows[0].v, "héllo 🌍 日本語")
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("reads a row whose leading column is empty or NULL", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        // A row starting 0x00 and at least seven bytes long would read as an OK
+        // packet, and one starting 0xfb as a LOCAL INFILE request, if packet
+        // classification ignored the phase it is in.
+        const rows = rowsOf(
+          yield* conn.query("SELECT '' AS a, 'aaaaaaaa' AS b UNION ALL SELECT NULL, 'bbbbbbbb'")
+        )
+        assert.deepStrictEqual(rows, [{ a: "", b: "aaaaaaaa" }, { a: null, b: "bbbbbbbb" }])
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("renders dateStrings to the column's precision on both protocols", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect({ dateStrings: true })
+        yield* conn.query(`CREATE TABLE stamps (
+          d0 DATETIME(0), d3 DATETIME(3), d6 DATETIME(6), dz DATETIME(6),
+          t0 TIME(0), t3 TIME(3), t6 TIME(6), tneg TIME(6), tz TIME(6)
+        )`)
+        yield* conn.query(`INSERT INTO stamps VALUES (
+          '2024-01-02 03:04:05', '2024-01-02 03:04:05.123', '2024-01-02 03:04:05.123456',
+          '2024-01-02 03:04:05.000000',
+          '01:02:03', '01:02:03.123', '01:02:03.123456', '-838:59:58.999999', '01:02:03.000000'
+        )`)
+        const expected = {
+          d0: "2024-01-02 03:04:05",
+          d3: "2024-01-02 03:04:05.123",
+          d6: "2024-01-02 03:04:05.123456",
+          // Whole seconds: the binary protocol omits the microseconds field
+          // entirely, so the trailing zeroes can only come from the column.
+          dz: "2024-01-02 03:04:05.000000",
+          t0: "01:02:03",
+          t3: "01:02:03.123",
+          t6: "01:02:03.123456",
+          tneg: "-838:59:58.999999",
+          tz: "01:02:03.000000"
+        }
+        const columns = Object.keys(expected).join(", ")
+        // The binary protocol carries the parts and has to format them; the
+        // text protocol carries the server's own string. They must agree.
+        const [binary] = yield* conn.execute(`SELECT ${columns} FROM stamps`, [])
+        assert.deepStrictEqual(resultSet(binary).rows[0], expected)
+        const [text] = yield* conn.query(`SELECT ${columns} FROM stamps`)
+        assert.deepStrictEqual(resultSet(text).rows[0], expected)
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+
+    it.effect("decodes NULL in every column type", () =>
+      Effect.gen(function*() {
+        const conn = yield* connect()
+        yield* conn.query("CREATE TABLE nulls (i INT, b BIGINT, d DECIMAL(4,2), t TEXT, j JSON, dt DATETIME)")
+        yield* conn.query("INSERT INTO nulls VALUES (NULL, NULL, NULL, NULL, NULL, NULL)")
+        const rows = rowsOf(yield* conn.query("SELECT * FROM nulls"))
+        assert.deepStrictEqual(rows[0], { i: null, b: null, d: null, t: null, j: null, dt: null })
+      }).pipe(Effect.scoped), { timeout: 60_000 })
+  })
+})

--- a/packages/sql/mysql/test/MysqlTypes.test.ts
+++ b/packages/sql/mysql/test/MysqlTypes.test.ts
@@ -1,0 +1,256 @@
+import { MysqlProtocol, MysqlTypes } from "@effect/sql-mysql"
+import { assert, describe, it } from "@effect/vitest"
+
+/**
+ * Decoding driven straight from bytes, with no server involved. The
+ * integration suite proves the mapping agrees with MySQL; this one covers the
+ * edges a server will not readily produce - boundary values, unsigned wrap,
+ * truncated fields - and costs no container to do it.
+ */
+
+const column = (overrides: Partial<MysqlProtocol.Column> = {}): MysqlProtocol.Column => ({
+  schema: "test",
+  table: "t",
+  orgTable: "t",
+  name: "c",
+  orgName: "c",
+  collation: MysqlProtocol.defaultCollation,
+  columnLength: 255,
+  type: MysqlProtocol.ColumnType.varString,
+  flags: MysqlProtocol.ColumnFlags.none,
+  decimals: 0,
+  ...overrides
+})
+
+const unsigned = (type: number, decimals = 0): MysqlProtocol.Column =>
+  column({ type, decimals, flags: MysqlProtocol.ColumnFlags.of([MysqlProtocol.ColumnFlag.unsigned]) })
+
+const binaryColumn = (type: number): MysqlProtocol.Column => column({ type, collation: MysqlProtocol.binaryCollation })
+
+/** Decodes one text-protocol field, which arrives as the value's digits. */
+const text = (
+  col: MysqlProtocol.Column,
+  value: string,
+  options: MysqlTypes.DecodeOptions = {}
+): unknown => {
+  const bytes = new TextEncoder().encode(value)
+  return MysqlTypes.makeTextFieldReader([col], options)(bytes, 0, bytes.length, 0)
+}
+
+/** Decodes one binary-protocol field from its exact bytes. */
+const binary = (
+  col: MysqlProtocol.Column,
+  bytes: ReadonlyArray<number>,
+  options: MysqlTypes.DecodeOptions = {}
+): unknown => {
+  const buffer = new Uint8Array(bytes)
+  // A binary reader returns the value with the offset just past it, because
+  // fields are packed back to back with no length prefix of their own.
+  return MysqlTypes.makeBinaryFieldReader([col], options)(buffer, 0, buffer.length, 0)[0]
+}
+
+const T = MysqlProtocol.ColumnType
+
+describe("MysqlTypes", () => {
+  describe("integers", () => {
+    it("decodes the signed boundaries", () => {
+      assert.strictEqual(text(column({ type: T.tiny }), "-128"), -128)
+      assert.strictEqual(text(column({ type: T.tiny }), "127"), 127)
+      assert.strictEqual(text(column({ type: T.long }), "-2147483648"), -2147483648)
+      assert.strictEqual(text(column({ type: T.long }), "2147483647"), 2147483647)
+    })
+
+    it("reads unsigned columns as unsigned rather than wrapping negative", () => {
+      // The same byte is 255 unsigned and -1 signed; only the column flag says which.
+      assert.strictEqual(binary(unsigned(T.tiny), [0xff]), 255)
+      assert.strictEqual(binary(column({ type: T.tiny }), [0xff]), -1)
+      assert.strictEqual(binary(unsigned(T.short), [0xff, 0xff]), 65535)
+      assert.strictEqual(binary(column({ type: T.short }), [0xff, 0xff]), -1)
+      assert.strictEqual(binary(unsigned(T.long), [0xff, 0xff, 0xff, 0xff]), 4294967295)
+      assert.strictEqual(binary(column({ type: T.long }), [0xff, 0xff, 0xff, 0xff]), -1)
+    })
+
+    it("keeps BIGINT exact past 2^53", () => {
+      // 9007199254740993 is the first odd integer a double cannot hold.
+      assert.strictEqual(text(column({ type: T.longlong }), "9007199254740993"), BigInt("9007199254740993"))
+      assert.strictEqual(
+        text(unsigned(T.longlong), "18446744073709551615"),
+        BigInt("18446744073709551615")
+      )
+      assert.strictEqual(
+        binary(unsigned(T.longlong), [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
+        BigInt("18446744073709551615")
+      )
+      assert.strictEqual(
+        binary(column({ type: T.longlong }), [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
+        BigInt("-1")
+      )
+    })
+
+    it("gives up exactness for a number when asked", () => {
+      const options = { bigintAsNumber: true }
+      assert.strictEqual(text(column({ type: T.longlong }), "42", options), 42)
+      assert.strictEqual(binary(column({ type: T.longlong }), [1, 0, 0, 0, 0, 0, 0, 0], options), 1)
+    })
+
+    it("does not turn TINYINT(1) into a boolean", () => {
+      // MySQL has no boolean, and a caller reading a TINYINT column should not
+      // have to guess whether its width changed the type.
+      assert.strictEqual(text(column({ type: T.tiny, columnLength: 1 }), "1"), 1)
+      assert.strictEqual(text(column({ type: T.tiny, columnLength: 1 }), "0"), 0)
+    })
+  })
+
+  describe("decimals and floats", () => {
+    it("keeps DECIMAL as its digits rather than rounding through a double", () => {
+      const value = "12345678901234567890.12345678901234567890"
+      assert.strictEqual(text(column({ type: T.newdecimal }), value), value)
+      assert.strictEqual(text(column({ type: T.decimal }), "0.1"), "0.1")
+    })
+
+    it("decodes FLOAT and DOUBLE from their IEEE bytes", () => {
+      assert.strictEqual(binary(column({ type: T.double }), [0, 0, 0, 0, 0, 0, 0xf0, 0x3f]), 1)
+      assert.strictEqual(binary(column({ type: T.float }), [0, 0, 0x80, 0x3f]), 1)
+    })
+  })
+
+  describe("temporal", () => {
+    it("decodes DATE as a plain string, with no zone invented", () => {
+      assert.strictEqual(text(column({ type: T.date }), "2024-01-02"), "2024-01-02")
+      assert.strictEqual(binary(column({ type: T.date }), [4, 0xe8, 0x07, 1, 2]), "2024-01-02")
+    })
+
+    it("decodes DATETIME as epoch milliseconds", () => {
+      assert.strictEqual(
+        text(column({ type: T.datetime }), "2024-01-02 03:04:05"),
+        Date.UTC(2024, 0, 2, 3, 4, 5)
+      )
+    })
+
+    it("decodes TIME as signed microseconds, because it is a duration", () => {
+      // MySQL TIME spans -838:59:59 to 838:59:59, so it is not a clock reading
+      // and can be negative.
+      assert.strictEqual(text(column({ type: T.time }), "01:02:03"), BigInt(3723) * BigInt(1000000))
+      assert.strictEqual(text(column({ type: T.time }), "-01:02:03"), -BigInt(3723) * BigInt(1000000))
+      assert.strictEqual(text(column({ type: T.time }), "838:59:59"), BigInt(3020399) * BigInt(1000000))
+    })
+
+    it("renders dateStrings to the column's declared precision", () => {
+      // The binary form omits the microseconds field when the value has none,
+      // so the trailing zeroes can only come from the column.
+      const wholeSecond = [7, 0xe8, 0x07, 1, 2, 3, 4, 5]
+      assert.strictEqual(
+        binary(column({ type: T.datetime, decimals: 6 }), wholeSecond, { dateStrings: true }),
+        "2024-01-02 03:04:05.000000"
+      )
+      assert.strictEqual(
+        binary(column({ type: T.datetime, decimals: 0 }), wholeSecond, { dateStrings: true }),
+        "2024-01-02 03:04:05"
+      )
+      assert.strictEqual(
+        binary(column({ type: T.datetime, decimals: 3 }), [11, 0xe8, 0x07, 1, 2, 3, 4, 5, 0x40, 0xe2, 1, 0], {
+          dateStrings: true
+        }),
+        "2024-01-02 03:04:05.123"
+      )
+    })
+
+    it("decodes MySQL's zero date without throwing, though it has no real epoch", () => {
+      // '0000-00-00 00:00:00' is a value MySQL accepts and no calendar has.
+      // It decodes rather than failing the row; callers who allow zero dates
+      // want `dateStrings` so they can see it for what it is.
+      assert.isNumber(binary(column({ type: T.datetime }), [0]))
+      assert.strictEqual(
+        binary(column({ type: T.datetime }), [0], { dateStrings: true }),
+        "0000-00-00 00:00:00"
+      )
+    })
+  })
+
+  describe("text and bytes", () => {
+    it("tells BLOB from TEXT by the collation, not the type byte", () => {
+      // They share a type byte; only the binary collation separates them.
+      assert.strictEqual(text(column({ type: T.blob }), "hello"), "hello")
+      assert.deepStrictEqual(
+        text(binaryColumn(T.blob), "hi"),
+        new Uint8Array([0x68, 0x69])
+      )
+      assert.deepStrictEqual(
+        text(binaryColumn(T.varString), "hi"),
+        new Uint8Array([0x68, 0x69])
+      )
+    })
+
+    it("decodes multi-byte UTF-8 correctly at and past the ASCII fast path", () => {
+      // Short values take a per-character loop and longer ones TextDecoder, so
+      // both sides of that threshold need to agree.
+      assert.strictEqual(text(column(), "héllo"), "héllo")
+      assert.strictEqual(text(column(), "日本語のテキストです"), "日本語のテキストです")
+      assert.strictEqual(text(column(), "🎉"), "🎉")
+    })
+
+    it("parses JSON, which MySQL sends as text even though it stores binary", () => {
+      assert.deepStrictEqual(text(column({ type: T.json }), `{"a":[1,2]}`), { a: [1, 2] })
+    })
+
+    it("decodes BIT as a bigint", () => {
+      assert.strictEqual(binary(column({ type: T.bit }), [2, 0x01, 0x00]), BigInt(256))
+      assert.strictEqual(binary(column({ type: T.bit }), [1, 0x05]), BigInt(5))
+    })
+
+    it("hands back GEOMETRY as raw bytes", () => {
+      assert.deepStrictEqual(binary(binaryColumn(T.geometry), [2, 0xaa, 0xbb]), new Uint8Array([0xaa, 0xbb]))
+    })
+  })
+
+  describe("NULL", () => {
+    it("reads a text field of size -1 as NULL", () => {
+      // The text protocol marks NULL with 0xfb, which the row reader turns
+      // into a size of -1 before the field reader sees it.
+      assert.strictEqual(MysqlTypes.makeTextFieldReader([column()])(new Uint8Array(), 0, -1, 0), null)
+    })
+  })
+
+  describe("rejecting malformed values", () => {
+    it("fails rather than inventing a value for a truncated field", () => {
+      // A binary DOUBLE needs eight bytes; four is a desync, not a zero.
+      assert.throws(() => binary(column({ type: T.double }), [0, 0, 0, 0]))
+      assert.throws(() => binary(column({ type: T.longlong }), [1, 2, 3]))
+    })
+
+    it("fails on invalid UTF-8 rather than substituting replacement characters", () => {
+      const invalid = new Uint8Array([0xff, 0xfe, 0xfd])
+      assert.throws(() => MysqlTypes.makeTextFieldReader([column()])(invalid, 0, invalid.length, 0))
+    })
+
+    it("fails on malformed JSON", () => {
+      assert.throws(() => text(column({ type: T.json }), "{not json"))
+    })
+  })
+
+  describe("parameter binding", () => {
+    const typeOf = (value: unknown): number => MysqlTypes.bindParameter(value).type
+
+    it("infers a type from the JavaScript value", () => {
+      assert.strictEqual(typeOf(true), T.tiny)
+      assert.strictEqual(typeOf(1), T.long)
+      assert.strictEqual(typeOf(2147483648), T.longlong)
+      assert.strictEqual(typeOf(1.5), T.double)
+      assert.strictEqual(typeOf(BigInt(1)), T.longlong)
+      assert.strictEqual(typeOf("a"), T.varString)
+      assert.strictEqual(typeOf(new Uint8Array([1])), T.blob)
+      assert.strictEqual(typeOf(new Date()), T.datetime)
+    })
+
+    it("binds null and undefined alike, since both mean SQL NULL", () => {
+      assert.strictEqual(typeOf(null), T.null)
+      assert.strictEqual(typeOf(undefined), T.null)
+      assert.strictEqual(MysqlTypes.bindParameter(null).write, undefined)
+    })
+
+    it("marks a bigint above the signed maximum as unsigned", () => {
+      assert.isTrue(MysqlTypes.bindParameter(BigInt("18446744073709551615")).unsigned)
+      assert.isFalse(MysqlTypes.bindParameter(BigInt(1)).unsigned)
+    })
+  })
+})

--- a/packages/sql/mysql/test/Persistence.integration.test.ts
+++ b/packages/sql/mysql/test/Persistence.integration.test.ts
@@ -1,0 +1,87 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect, Layer, Schema } from "effect"
+import * as PersistedCacheTest from "effect-test/unstable/persistence/PersistedCacheTest"
+import * as PersistedQueueTest from "effect-test/unstable/persistence/PersistedQueueTest"
+import * as SqlCleanupTest from "effect-test/unstable/persistence/SqlCleanupTest"
+import { TestClock } from "effect/testing"
+import { PersistedQueue, Persistence } from "effect/unstable/persistence"
+import { SqlClient } from "effect/unstable/sql"
+import { MysqlContainer } from "./utils.ts"
+
+it.layer(MysqlContainer.layerClient, { timeout: "90 seconds" })("Persistence", (it) => {
+  PersistedCacheTest.suiteWith("sql-mysql-multi", Persistence.layerSqlMultiTable, it)
+
+  PersistedQueueTest.suiteWith("sql-mysql", PersistedQueue.layerStoreSql(), it)
+
+  // elements are stored in a MEDIUMTEXT column, so payloads must survive the
+  // 64KB TEXT limit
+  it.effect("round-trips queue payloads larger than 64KB", () =>
+    Effect.gen(function*() {
+      const store = yield* PersistedQueue.makeStoreSql({
+        tableName: "effect_queue_large_payload",
+        pollInterval: "10 millis"
+      })
+      const factory = yield* PersistedQueue.makeFactory.pipe(
+        Effect.provideService(PersistedQueue.PersistedQueueStore, store)
+      )
+      const queue = yield* factory.make({ name: "large-payload", schema: Schema.String })
+
+      const payload = "x".repeat(200_000)
+      yield* queue.offer(payload)
+      const value = yield* queue.take(Effect.succeed)
+      assert.strictEqual(value, payload)
+    }).pipe(TestClock.withLive), { timeout: 30000 })
+
+  describe("single-table persistence", { concurrent: false }, () => {
+    PersistedCacheTest.suiteWith("sql-mysql-single", Persistence.layerSql, it)
+
+    it.effect("deletes expired entries in batches", () =>
+      Effect.gen(function*() {
+        const sql = (yield* SqlClient.SqlClient).withoutTransforms()
+        const table = sql("effect_persistence")
+        const expiredCount = sql<{ readonly count: number }>`
+          SELECT COUNT(*) AS count FROM ${table} WHERE store_id = 'expired'
+        `.pipe(Effect.map((rows) => Number(rows[0].count)))
+        // Reset the table left by the single-table cache suite so cleanup builds its own schema and index.
+        yield* sql`DROP TABLE IF EXISTS ${table}`
+        yield* sql`
+          CREATE TABLE ${table} (
+            store_id VARCHAR(191) NOT NULL,
+            id VARCHAR(191) NOT NULL,
+            value TEXT NOT NULL,
+            expires BIGINT,
+            PRIMARY KEY (store_id, id)
+          )
+        `
+
+        const entries = Array.from({ length: SqlCleanupTest.expiredEntryCount }, (_, i) => ({
+          store_id: "expired",
+          id: String(i),
+          value: "{}",
+          expires: SqlCleanupTest.expiredAtEpoch
+        }))
+        yield* sql`INSERT INTO ${table} ${sql.insert(entries)}`.unprepared
+        yield* sql`
+          INSERT INTO ${table} (store_id, id, value, expires)
+          VALUES ('live', 'live', '{}', NULL), ('live', 'future', '{}', ${SqlCleanupTest.futureExpiresAt})
+        `
+
+        yield* Layer.build(Persistence.layerBackingSql).pipe(TestClock.withLive)
+
+        const expired = yield* SqlCleanupTest.waitForCount(expiredCount, (count) => count === 0)
+        assert.strictEqual(expired, 0)
+        const live = yield* sql<{ readonly count: number }>`
+          SELECT COUNT(*) AS count FROM ${table} WHERE store_id = 'live'
+        `
+        assert.strictEqual(Number(live[0].count), 2)
+
+        const indexes = yield* sql<{ readonly count: number }>`
+          SELECT COUNT(*) AS count FROM information_schema.statistics
+          WHERE table_schema = DATABASE()
+            AND table_name = 'effect_persistence'
+            AND index_name = 'effect_persistence_expires_idx'
+        `
+        assert.strictEqual(Number(indexes[0].count), 1)
+      }), { timeout: SqlCleanupTest.testTimeout })
+  })
+})

--- a/packages/sql/mysql/test/SqlErrorClassification.test.ts
+++ b/packages/sql/mysql/test/SqlErrorClassification.test.ts
@@ -1,0 +1,106 @@
+import { classifyErr, classifyErrno, constraintFromMessage } from "@effect/sql-mysql/internal/sqlError"
+import { assert, describe, it } from "@effect/vitest"
+import type { UniqueViolation } from "effect/unstable/sql/SqlError"
+
+const props = { cause: new Error("boom"), message: "test", operation: "execute" }
+
+const tagOf = (
+  errno: number | undefined,
+  sqlState: string | undefined,
+  message?: string
+): string => classifyErrno(errno, sqlState, message, props)._tag
+
+describe("error classification", () => {
+  describe("by error number", () => {
+    const cases: ReadonlyArray<readonly [number, string]> = [
+      [1040, "ConnectionError"], // too many connections
+      [1129, "ConnectionError"], // host blocked
+      [1203, "ConnectionError"], // user exceeded max connections
+      [1045, "AuthenticationError"], // access denied
+      [1044, "AuthorizationError"], // access denied for database
+      [1142, "AuthorizationError"], // command denied
+      [1064, "SqlSyntaxError"], // parse error
+      [1054, "SqlSyntaxError"], // unknown column
+      [1146, "SqlSyntaxError"], // table does not exist
+      [1062, "UniqueViolation"], // duplicate entry
+      [1048, "ConstraintError"], // column cannot be null
+      [1452, "ConstraintError"], // foreign key
+      [1213, "DeadlockError"],
+      [1205, "LockTimeoutError"],
+      [3024, "StatementTimeoutError"]
+    ]
+    for (const [errno, expected] of cases) {
+      it(`maps ${errno} to ${expected}`, () => {
+        assert.strictEqual(tagOf(errno, undefined), expected)
+      })
+    }
+  })
+
+  describe("by SQLSTATE class, for numbers the table does not name", () => {
+    // 9999 is deliberately absent from every errno set, so these prove the
+    // SQLSTATE fallback rather than the table.
+    const cases: ReadonlyArray<readonly [string, string]> = [
+      ["40001", "SerializationError"],
+      ["08S01", "ConnectionError"],
+      ["28000", "AuthenticationError"],
+      ["42S02", "SqlSyntaxError"],
+      ["23000", "ConstraintError"]
+    ]
+    for (const [state, expected] of cases) {
+      it(`maps SQLSTATE ${state} to ${expected}`, () => {
+        assert.strictEqual(tagOf(9999, state), expected)
+      })
+    }
+  })
+
+  it("prefers the error number over the SQLSTATE class", () => {
+    // 1213 is a deadlock, and MySQL reports it under SQLSTATE 40001, which
+    // alone would say SerializationError. Retrying differs between the two,
+    // so the more specific number has to win.
+    assert.strictEqual(tagOf(1213, "40001"), "DeadlockError")
+    // 1045 arrives with 28000, which agrees; 1044 arrives with 42000, which
+    // does not, and authorization is the accurate answer.
+    assert.strictEqual(tagOf(1044, "42000"), "AuthorizationError")
+  })
+
+  it("falls back to UnknownError when neither is recognised", () => {
+    assert.strictEqual(tagOf(9999, "HY000"), "UnknownError")
+    assert.strictEqual(tagOf(undefined, undefined), "UnknownError")
+  })
+
+  describe("duplicate-entry constraint names", () => {
+    const constraintOf = (message: string): string =>
+      (classifyErrno(1062, "23000", message, props) as UniqueViolation).constraint
+
+    it("reads a single-quoted index name", () => {
+      assert.strictEqual(
+        constraintOf("Duplicate entry 'a' for key 'users.email_unique'"),
+        "users.email_unique"
+      )
+    })
+    it("reads a backtick-quoted index name", () => {
+      assert.strictEqual(constraintOf("Duplicate entry 'a' for key `PRIMARY`"), "PRIMARY")
+    })
+    it("reads an unquoted index name", () => {
+      assert.strictEqual(constraintOf("Duplicate entry 'a' for key PRIMARY"), "PRIMARY")
+    })
+    it("reports unknown when the message names no key", () => {
+      assert.strictEqual(constraintOf("Duplicate entry 'a'"), "unknown")
+      assert.strictEqual(constraintFromMessage(undefined), "unknown")
+      assert.strictEqual(constraintFromMessage("for key '   '"), "unknown")
+    })
+  })
+
+  it("carries the server's number, state and message onto the cause", () => {
+    const reason = classifyErr(
+      { code: 1062, sqlState: "23000", message: "Duplicate entry 'a' for key 'PRIMARY'" },
+      "MysqlConnection: Failed to execute statement",
+      "execute"
+    )
+    assert.strictEqual(reason._tag, "UniqueViolation")
+    const cause = reason.cause as { errno: number; sqlState: string; sqlMessage: string }
+    assert.strictEqual(cause.errno, 1062)
+    assert.strictEqual(cause.sqlState, "23000")
+    assert.include(cause.sqlMessage, "Duplicate entry")
+  })
+})

--- a/packages/sql/mysql/test/SqlEventLogServerUnencrypted.integration.test.ts
+++ b/packages/sql/mysql/test/SqlEventLogServerUnencrypted.integration.test.ts
@@ -1,0 +1,7 @@
+import * as SqlEventLogServerUnencryptedStorageTest from "effect-test/unstable/eventlog/SqlEventLogServerUnencryptedStorageTest"
+import { MysqlContainer } from "./utils.ts"
+
+SqlEventLogServerUnencryptedStorageTest.suite(
+  "sql-mysql",
+  MysqlContainer.layerClient
+)

--- a/packages/sql/mysql/test/escape.test.ts
+++ b/packages/sql/mysql/test/escape.test.ts
@@ -1,0 +1,145 @@
+import { bindParameters, escapeValue } from "@effect/sql-mysql/internal/escape"
+import { assert, describe, it } from "@effect/vitest"
+
+const throwsCodecError = (run: () => unknown): void => {
+  try {
+    run()
+  } catch (error) {
+    assert.strictEqual((error as { readonly _tag?: string })._tag, "MysqlCodecError")
+    return
+  }
+  assert.fail("Expected MysqlCodecError")
+}
+
+describe("escape", () => {
+  describe("escapeValue", () => {
+    it("renders null and undefined as NULL", () => {
+      assert.strictEqual(escapeValue(null), "NULL")
+      assert.strictEqual(escapeValue(undefined), "NULL")
+    })
+
+    it("quotes strings", () => {
+      assert.strictEqual(escapeValue("alice"), "'alice'")
+      assert.strictEqual(escapeValue(""), "''")
+    })
+
+    it("escapes quotes so a value cannot end its own literal", () => {
+      assert.strictEqual(escapeValue("O'Brien"), "'O\\'Brien'")
+      assert.strictEqual(escapeValue("' OR 1=1 -- "), "'\\' OR 1=1 -- '")
+      assert.strictEqual(escapeValue("say \"hi\""), "'say \\\"hi\\\"'")
+    })
+
+    it("escapes backslashes, so an escaped quote cannot be smuggled in", () => {
+      // Without escaping the backslash, `\'` would leave the quote unescaped
+      // and close the literal.
+      assert.strictEqual(escapeValue("\\' OR 1=1"), "'\\\\\\' OR 1=1'")
+    })
+
+    it("escapes control characters MySQL treats specially", () => {
+      assert.strictEqual(escapeValue("a\0b"), "'a\\0b'")
+      assert.strictEqual(escapeValue("a\nb"), "'a\\nb'")
+      assert.strictEqual(escapeValue("a\rb"), "'a\\rb'")
+      assert.strictEqual(escapeValue("a\tb"), "'a\\tb'")
+      assert.strictEqual(escapeValue("a\bb"), "'a\\bb'")
+      assert.strictEqual(escapeValue("a\x1ab"), "'a\\Zb'")
+    })
+
+    it("renders numbers and bigints unquoted", () => {
+      assert.strictEqual(escapeValue(42), "42")
+      assert.strictEqual(escapeValue(-1.5), "-1.5")
+      assert.strictEqual(escapeValue(9007199254740993n), "9007199254740993")
+    })
+
+    it("refuses non-finite numbers rather than emitting invalid SQL", () => {
+      throwsCodecError(() => escapeValue(Number.NaN))
+      throwsCodecError(() => escapeValue(Number.POSITIVE_INFINITY))
+    })
+
+    it("renders booleans as 1 and 0", () => {
+      assert.strictEqual(escapeValue(true), "1")
+      assert.strictEqual(escapeValue(false), "0")
+    })
+
+    it("renders bytes as a hex literal", () => {
+      assert.strictEqual(escapeValue(new Uint8Array([0xde, 0xad, 0x00, 0x0f])), "X'dead000f'")
+      assert.strictEqual(escapeValue(new Uint8Array(0)), "X''")
+    })
+
+    it("renders a Date as a UTC datetime literal", () => {
+      assert.strictEqual(
+        escapeValue(new Date(Date.UTC(2026, 8, 10, 14, 30, 5, 123))),
+        "'2026-09-10 14:30:05.123'"
+      )
+    })
+
+    it("refuses an invalid Date", () => {
+      throwsCodecError(() => escapeValue(new Date(Number.NaN)))
+    })
+
+    it("renders an array as a comma-separated list, which sql.in needs", () => {
+      assert.strictEqual(escapeValue([1, "two", null]), "1, 'two', NULL")
+    })
+
+    it("renders a plain object as JSON", () => {
+      assert.strictEqual(escapeValue({ a: 1 }), "'{\\\"a\\\":1}'")
+    })
+  })
+
+  describe("bindParameters", () => {
+    it("substitutes in order", () => {
+      assert.strictEqual(
+        bindParameters("SELECT * FROM t WHERE a = ? AND b = ?", [1, "x"]),
+        "SELECT * FROM t WHERE a = 1 AND b = 'x'"
+      )
+    })
+
+    it("returns the statement untouched when there are no parameters", () => {
+      assert.strictEqual(bindParameters("SELECT 1", []), "SELECT 1")
+    })
+
+    it("leaves a question mark inside a string literal alone", () => {
+      assert.strictEqual(
+        bindParameters("SELECT 'why?' AS q, ? AS p", [1]),
+        "SELECT 'why?' AS q, 1 AS p"
+      )
+    })
+
+    it("leaves a question mark inside a double-quoted literal alone", () => {
+      assert.strictEqual(bindParameters(`SELECT "why?", ?`, [1]), `SELECT "why?", 1`)
+    })
+
+    it("leaves a question mark inside a quoted identifier alone", () => {
+      assert.strictEqual(bindParameters("SELECT `wat?`, ?", [1]), "SELECT `wat?`, 1")
+    })
+
+    it("handles a doubled quote inside a literal", () => {
+      assert.strictEqual(bindParameters("SELECT 'it''s ?', ?", [1]), "SELECT 'it''s ?', 1")
+    })
+
+    it("handles a backslash-escaped quote inside a literal", () => {
+      assert.strictEqual(bindParameters("SELECT 'it\\'s ?', ?", [1]), "SELECT 'it\\'s ?', 1")
+    })
+
+    it("leaves a question mark inside comments alone", () => {
+      assert.strictEqual(bindParameters("SELECT 1 -- what?\n, ?", [2]), "SELECT 1 -- what?\n, 2")
+      assert.strictEqual(bindParameters("SELECT 1 # what?\n, ?", [2]), "SELECT 1 # what?\n, 2")
+      assert.strictEqual(bindParameters("SELECT /* what? */ ?", [2]), "SELECT /* what? */ 2")
+    })
+
+    it("does not let a substituted value introduce a new placeholder", () => {
+      // The '?' in the first value must not consume the second parameter.
+      assert.strictEqual(
+        bindParameters("SELECT ?, ?", ["a?b", "c"]),
+        "SELECT 'a?b', 'c'"
+      )
+    })
+
+    it("rejects too few parameters", () => {
+      throwsCodecError(() => bindParameters("SELECT ?, ?", [1]))
+    })
+
+    it("rejects too many parameters", () => {
+      throwsCodecError(() => bindParameters("SELECT ?", [1, 2]))
+    })
+  })
+})

--- a/packages/sql/mysql/test/reply.test.ts
+++ b/packages/sql/mysql/test/reply.test.ts
@@ -1,0 +1,202 @@
+import { MysqlProtocol } from "@effect/sql-mysql"
+import type { Completed } from "@effect/sql-mysql/internal/reply"
+import { makeReader, readReply, textRows } from "@effect/sql-mysql/internal/reply"
+import { assert, describe, it } from "@effect/vitest"
+import * as Effect from "effect/Effect"
+import * as Queue from "effect/Queue"
+import * as Result from "effect/Result"
+import type { SqlError } from "effect/unstable/sql/SqlError"
+
+const success = <A, E>(result: Result.Result<A, E>): A => {
+  assert.isTrue(Result.isSuccess(result), "expected a success")
+  return (result as Result.Success<A, E>).success
+}
+
+const write = (run: Parameters<typeof MysqlProtocol.encodeWith>[0]): Uint8Array =>
+  success(MysqlProtocol.encodeWith(run))
+
+/** The result set a statement produced, failing the test if it produced counters. */
+const resultSet = <A>(
+  completed: Completed<A> | undefined
+): Extract<Completed<A>, { _tag: "ResultSet" }> => {
+  if (completed === undefined || completed._tag !== "ResultSet") {
+    throw new Error(`expected a result set, got ${completed === undefined ? "nothing" : completed._tag}`)
+  }
+  return completed
+}
+
+const packet = (payload: Uint8Array): MysqlProtocol.Packet => ({ sequenceId: 0, payload })
+
+/** The header that opens a result set, carrying its column count. */
+const columnCount = (count: number) => packet(write((w) => w.lenencInt(count)))
+
+const columnDefinition = (name: string, type: number) =>
+  packet(write((w) => {
+    w.lenencString("def")
+    w.lenencString("test")
+    w.lenencString("t")
+    w.lenencString("t")
+    w.lenencString(name)
+    w.lenencString(name)
+    w.lenencInt(0x0c)
+    w.uint16(MysqlProtocol.defaultCollation)
+    w.uint32(255)
+    w.uint8(type)
+    w.uint16(0)
+    w.uint8(0)
+    w.fill(0, 2)
+  }))
+
+const row = (...values: ReadonlyArray<string>) =>
+  packet(write((w) => {
+    for (const value of values) w.lenencString(value)
+  }))
+
+/** A row whose first field claims more bytes than the packet holds. */
+const truncatedRow = () => packet(new Uint8Array([0x05, 0x61, 0x62]))
+
+const ok = (statusFlags: number, affectedRows = 0) =>
+  packet(write((w) => {
+    w.uint8(0x00)
+    w.lenencInt(affectedRows)
+    w.lenencInt(0)
+    w.uint16(statusFlags)
+    w.uint16(0)
+  }))
+
+/** The packet that ends a result set: an OK wearing the 0xfe header. */
+const endOfRows = (statusFlags: number) =>
+  packet(write((w) => {
+    w.uint8(0xfe)
+    w.lenencInt(0)
+    w.lenencInt(0)
+    w.uint16(statusFlags)
+    w.uint16(0)
+  }))
+
+const autocommit = 2
+const moreResults = autocommit + 8
+
+const readerOf = (packets: ReadonlyArray<MysqlProtocol.Packet>) =>
+  Effect.map(Queue.make<MysqlProtocol.Packet, SqlError>(), (queue) => {
+    Queue.offerAllUnsafe(queue, packets)
+    return { reader: makeReader(queue), queue }
+  })
+
+/** Reads a reply, reporting each statement's rows as bare value arrays. */
+const read = (packets: ReadonlyArray<MysqlProtocol.Packet>) =>
+  Effect.flatMap(
+    readerOf(packets),
+    ({ reader }) => readReply(reader, textRows({}), (_, values) => values)
+  )
+
+describe("reply", () => {
+  it.effect("reads a statement that produced no rows", () =>
+    Effect.gen(function*() {
+      const statements = yield* read([ok(autocommit, 3)])
+      assert.strictEqual(statements.length, 1)
+      // No rows is the tag's business now, not an empty array's.
+      assert.strictEqual(statements[0]._tag, "Ok")
+      assert.strictEqual(statements[0].ok.affectedRows, 3)
+    }))
+
+  it.effect("reads a result set", () =>
+    Effect.gen(function*() {
+      const statements = yield* read([
+        columnCount(2),
+        columnDefinition("a", MysqlProtocol.ColumnType.varString),
+        columnDefinition("b", MysqlProtocol.ColumnType.long),
+        row("x", "1"),
+        row("y", "2"),
+        endOfRows(autocommit)
+      ])
+      assert.strictEqual(statements.length, 1)
+      assert.deepStrictEqual(resultSet(statements[0]).rows, [["x", 1], ["y", 2]])
+      assert.deepStrictEqual(resultSet(statements[0]).columns.map((column) => column.name), ["a", "b"])
+    }))
+
+  it.effect("reads one entry per statement of a multi-statement reply", () =>
+    Effect.gen(function*() {
+      const statements = yield* read([
+        ok(moreResults, 1),
+        columnCount(1),
+        columnDefinition("a", MysqlProtocol.ColumnType.varString),
+        row("only"),
+        endOfRows(autocommit)
+      ])
+      assert.strictEqual(statements.length, 2)
+      assert.strictEqual(statements[0].ok.affectedRows, 1)
+      assert.deepStrictEqual(resultSet(statements[1]).rows, [["only"]])
+    }))
+
+  it.effect("reads a row whose first column is empty", () =>
+    Effect.gen(function*() {
+      // Starts 0x00 and is long enough to look like an OK packet, which is why
+      // classification has to know it is reading rows.
+      const statements = yield* read([
+        columnCount(2),
+        columnDefinition("a", MysqlProtocol.ColumnType.varString),
+        columnDefinition("b", MysqlProtocol.ColumnType.varString),
+        row("", "aaaaaaaa"),
+        endOfRows(autocommit)
+      ])
+      assert.deepStrictEqual(resultSet(statements[0]).rows, [["", "aaaaaaaa"]])
+    }))
+
+  it.effect("fails with the server's error", () =>
+    Effect.gen(function*() {
+      const err = packet(write((w) => {
+        w.uint8(0xff)
+        w.uint16(1062)
+        w.uint8(0x23)
+        w.utf8("23000")
+        w.utf8("Duplicate entry 'a' for key 'users.email'")
+      }))
+      const error = yield* Effect.flip(read([err]))
+      assert.strictEqual(error.reason._tag, "UniqueViolation")
+      assert.strictEqual((error.reason as { readonly constraint: string }).constraint, "users.email")
+    }))
+
+  it.effect("refuses a LOCAL INFILE request", () =>
+    Effect.gen(function*() {
+      const request = packet(new Uint8Array([0xfb, 0x2f, 0x74, 0x6d, 0x70]))
+      const error = yield* Effect.flip(read([request]))
+      assert.match(error.message, /LOCAL INFILE/)
+    }))
+
+  it.effect("reads the reply to its end before failing on a value it cannot decode", () =>
+    Effect.gen(function*() {
+      const { queue, reader } = yield* readerOf([
+        columnCount(1),
+        columnDefinition("a", MysqlProtocol.ColumnType.varString),
+        truncatedRow(),
+        row("after"),
+        endOfRows(autocommit)
+      ])
+      const error = yield* Effect.flip(readReply(reader, textRows({}), (_, values) => values))
+      assert.match(error.message, /Failed to read a row/)
+
+      // The session is reusable: the next reply reads cleanly off the same
+      // reader, which it could not if the first had been abandoned early.
+      Queue.offerAllUnsafe(queue, [ok(autocommit, 7)])
+      const next = yield* readReply(reader, textRows({}), (_, values) => values)
+      assert.strictEqual(next[0].ok.affectedRows, 7)
+    }))
+
+  it.effect("reads two result sets that arrive in one chunk", () =>
+    Effect.gen(function*() {
+      const statements = yield* read([
+        columnCount(1),
+        columnDefinition("a", MysqlProtocol.ColumnType.varString),
+        row("first"),
+        endOfRows(moreResults),
+        columnCount(1),
+        columnDefinition("b", MysqlProtocol.ColumnType.varString),
+        row("second"),
+        endOfRows(autocommit)
+      ])
+      assert.strictEqual(statements.length, 2)
+      assert.deepStrictEqual(resultSet(statements[0]).rows, [["first"]])
+      assert.deepStrictEqual(resultSet(statements[1]).rows, [["second"]])
+    }))
+})

--- a/packages/sql/mysql/test/utils.ts
+++ b/packages/sql/mysql/test/utils.ts
@@ -1,0 +1,92 @@
+import type { MysqlConnection } from "@effect/sql-mysql"
+import { MysqlClient } from "@effect/sql-mysql"
+import type { StartedMySqlContainer } from "@testcontainers/mysql"
+import { MySqlContainer } from "@testcontainers/mysql"
+import { Context, Data, Effect, Layer, Redacted, String } from "effect"
+
+export class ContainerError extends Data.TaggedError("ContainerError")<{
+  cause: unknown
+}> {}
+
+/**
+ * The floor this package supports. `mysql:lts` now resolves to a 9.x release,
+ * so the suite pins the 8.x LTS to prove the declared target rather than
+ * whatever is newest.
+ */
+const image = "mysql:8.4"
+
+const makeMysqlContainer = () =>
+  new MySqlContainer(image).withHealthCheck({
+    test: [
+      "CMD-SHELL",
+      "MYSQL_PWD=\"$MYSQL_ROOT_PASSWORD\" mysqladmin ping --protocol TCP --host 127.0.0.1 --user root --silent"
+    ],
+    interval: 250,
+    timeout: 1000,
+    retries: 1000
+  })
+
+export class MysqlContainer extends Context.Service<
+  MysqlContainer,
+  StartedMySqlContainer
+>()("test/MysqlContainer") {
+  static readonly layer = Layer.effect(this)(
+    Effect.acquireRelease(
+      Effect.tryPromise({
+        try: () => makeMysqlContainer().start(),
+        catch: (cause) => new ContainerError({ cause })
+      }),
+      (container) => Effect.promise(() => container.stop())
+    )
+  )
+
+  static client = Layer.unwrap(
+    Effect.gen(function*() {
+      const container = yield* MysqlContainer
+      return MysqlClient.layer({ url: Redacted.make(container.getConnectionUri()) })
+    })
+  )
+
+  static layerClient = this.client.pipe(Layer.provide(this.layer))
+
+  static clientWithTransforms = Layer.unwrap(
+    Effect.gen(function*() {
+      const container = yield* MysqlContainer
+      return MysqlClient.layer({
+        url: Redacted.make(container.getConnectionUri()),
+        transformQueryNames: String.camelToSnake,
+        transformResultNames: String.snakeToCamel
+      })
+    })
+  )
+}
+
+/**
+ * The rows of the first statement in a reply.
+ *
+ * A `Result` says whether it was a result set or counters, so a test that
+ * knows it ran a `SELECT` says so here once rather than matching every time.
+ */
+export const rowsOf = (
+  results: ReadonlyArray<MysqlConnection.Result>
+): ReadonlyArray<MysqlConnection.Row> => resultSet(results[0]).rows
+
+/** The result set a statement produced, failing the test if it produced counters. */
+export const resultSet = (
+  result: MysqlConnection.Result | undefined
+): Extract<MysqlConnection.Result, { _tag: "ResultSet" }> => {
+  if (result === undefined || result._tag !== "ResultSet") {
+    throw new Error(`expected a result set, got ${result === undefined ? "nothing" : result._tag}`)
+  }
+  return result
+}
+
+/** The counters a statement produced, failing the test if it produced rows. */
+export const okResult = (
+  result: MysqlConnection.Result | undefined
+): Extract<MysqlConnection.Result, { _tag: "Ok" }> => {
+  if (result === undefined || result._tag !== "Ok") {
+    throw new Error(`expected counters, got ${result === undefined ? "nothing" : result._tag}`)
+  }
+  return result
+}

--- a/packages/sql/mysql/tsconfig.json
+++ b/packages/sql/mysql/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src"],
+  "references": [
+    { "path": "../../effect" }
+  ],
+  "compilerOptions": {
+    "types": ["node"]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -562,6 +562,27 @@ importers:
         specifier: workspace:^
         version: link:../../effect
 
+  packages/sql/mysql:
+    devDependencies:
+      '@effect/platform-node':
+        specifier: workspace:^
+        version: link:../../platform/node
+      '@effect/sql-mysql2':
+        specifier: workspace:^
+        version: link:../mysql2
+      '@testcontainers/mysql':
+        specifier: ^12.1.0
+        version: 12.1.0(supports-color@10.2.2)
+      '@types/node':
+        specifier: ^26.4.1
+        version: 26.4.1
+      effect:
+        specifier: workspace:^
+        version: link:../../effect
+      tinybench:
+        specifier: ^6.1.6
+        version: 6.1.6
+
   packages/sql/mysql2:
     dependencies:
       mysql2:

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -21,6 +21,7 @@
     { "path": "packages/sql/clickhouse" },
     { "path": "packages/sql/d1" },
     { "path": "packages/sql/libsql" },
+    { "path": "packages/sql/mysql" },
     { "path": "packages/sql/mysql2" },
     { "path": "packages/sql/mssql" },
     { "path": "packages/sql/pg" },

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -59,6 +59,8 @@
       "@effect/sql-libsql/*": ["./packages/sql/libsql/src/*.ts"],
       "@effect/sql-mssql": ["./packages/sql/mssql/src/index.ts"],
       "@effect/sql-mssql/*": ["./packages/sql/mssql/src/*.ts"],
+      "@effect/sql-mysql": ["./packages/sql/mysql/src/index.ts"],
+      "@effect/sql-mysql/*": ["./packages/sql/mysql/src/*.ts"],
       "@effect/sql-mysql2": ["./packages/sql/mysql2/src/index.ts"],
       "@effect/sql-mysql2/*": ["./packages/sql/mysql2/src/*.ts"],
       "@effect/sql-pg": ["./packages/sql/pg/src/index.ts"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -178,6 +178,21 @@ export default defineConfig({
       // MySQL starts a fresh container per integration test suite, so avoid competing
       // with the other container-backed projects on integration-test runners.
       ...project(
+        "@effect/sql-mysql",
+        "packages/sql/mysql",
+        true,
+        integrationTestsEnabled
+          ? {
+            test: {
+              fileParallelism: false,
+              sequence: {
+                groupOrder: 1
+              }
+            }
+          }
+          : {}
+      ),
+      ...project(
         "@effect/sql-mysql2",
         "packages/sql/mysql2",
         true,


### PR DESCRIPTION
Adds `packages/sql/mysql` (`@effect/sql-mysql`), a MySQL client that speaks the
client/server protocol directly rather than wrapping a driver. It has no runtime
dependencies — `node:net` and `node:tls` are the only transport — and targets
MySQL 8.0 and newer.

`packages/sql/pg` is the schematic throughout: the same pooled growable buffer
with `start`/`end` cursors, the same zero-copy row views, the same split between
a pure protocol module and a connection that owns the socket. `@effect/sql-mysql2`
is untouched and stays published; the two share the `SqlClient` contract.

## Why

MySQL users currently inherit `mysql2`'s pool, TLS handling, type coercion and
error objects — a dependency Effect does not control, allocation behaviour it
cannot tune, and errors that have to be reverse-engineered from driver
exceptions rather than read off the wire. This closes that gap the same way
`sql/pg` closed it for Postgres.

## Shape

| Module | Responsibility |
|---|---|
| `MysqlProtocol.ts` | Pure wire codec: framing, packet decoders, `COM_*` encoders. No I/O. |
| `MysqlTypes.ts` | Column model and JS mapping, for both the text and binary protocols. |
| `MysqlAuth.ts` | Four auth plugins, as pure `Result`-returning functions. |
| `MysqlConnection.ts` | Socket, TLS upgrade, handshake, commands, streaming, cancellation. |
| `MysqlPool.ts` / `MysqlClient.ts` | `Pool.makeWithTTL`, and the `SqlClient` adapter. |
| `MysqlMigrator.ts` | Core `Migrator` plus a `mysqldump` schema dump. |
| `internal/` | Buffer, packet-layout DSL, reply readers, escaping, error classification. |

Targeting MySQL 8 exclusively is load-bearing rather than incidental: it lets the
client *require* `CLIENT_DEPRECATE_EOF`, which removes EOF packets from result
sets and collapses the protocol's worst ambiguity into a single rule.

## Notes for review

- **Authentication.** `caching_sha2_password` (fast and full, including the
  RSA-OAEP key exchange full auth needs on a plaintext socket),
  `sha256_password`, `mysql_native_password`, and `mysql_clear_password`.
  The last sends the password unprotected and is refused unless the connection
  is encrypted. Both SHA-256 paths are integration-tested over TLS and RSA.
- **`LOAD DATA LOCAL INFILE` is refused.** `CLIENT_LOCAL_FILES` is never
  negotiated, so a server requesting one is a protocol violation.
- **`internal/escape.ts` is injection-critical.** MySQL's text protocol has no
  placeholders, so parameters are written into SQL there. 24 tests cover quote,
  backslash and control-character escaping, and placeholders appearing inside
  string literals, quoted identifiers and comments. Worth the closest look.
- **States the protocol distinguishes are carried, not inferred.** A
  statement's outcome is a tagged `Result` of `ResultSet | Ok`, so
  `affectedRows` and `lastInsertId` exist only where they mean something and
  nothing has to recover the distinction from an empty column list. A
  session's transport is a tagged `Tcp | Unix | Supplied` settled once at
  resolution rather than four optional fields of which several could be set at
  once. `Result.rowsOf` covers the common case of wanting rows.
- **Deliberately dropped:** pipelining (MySQL's sequence ids make pg's
  `PipelineEntry` machinery unsound), `LISTEN`/`NOTIFY`, `COPY`, a type
  registry (MySQL's type space is closed), and server-side cursors.
- **Behaviour that differs from `@effect/sql-mysql2`** — `BIGINT` as `bigint`,
  `DECIMAL` as `string`, temporal types as epoch milliseconds, session time zone
  pinned to UTC — is enumerated with opt-outs in the changeset.

## Why not `DateTime` and `BigDecimal`

The obvious question about the type mapping is why `DECIMAL` decodes to a
`string` and `DATETIME` to a number, when `effect` ships `BigDecimal` and
`DateTime` and both are plainly the nicer domain types.

The short answer is that decoding them here would be the wrong layer, and it is
the layer `sql/pg` already chose: it imports `DateTime` nowhere, decoding
`numeric` to `string`, `timestamp` to epoch milliseconds and `time` to `bigint`.
No SQL driver in the repo decodes to either type. A driver's job is to get the
value off the wire without losing anything; turning it into a domain type is
`Schema`'s job, and the bridges already exist and consume exactly what this
client emits:

```ts
Schema.BigDecimalFromString     // <- DECIMAL, NEWDECIMAL
Schema.DateTimeUtcFromMillis    // <- DATETIME, TIMESTAMP
```

That keeps the cost where the benefit is. A user selecting a `DECIMAL` column to
render it in a table pays for a string; one doing arithmetic on it opts into
`BigDecimal` through their schema and pays there.

Three reasons specific to the types also point the same way:

- **MySQL `TIME` is a duration, not an instant.** It is signed and spans
  -838:59:59 to 838:59:59, so `DateTime` cannot represent it at all. Signed
  microseconds map onto `Duration` instead.
- **`DATE` carries neither a time nor a zone.** Decoding to `DateTime` would
  have to invent both.
- **`DateTime.Utc` is millisecond-based** (`epochMilliseconds: number`), so it
  would not even be a precision win over the epoch milliseconds returned today.

That last point is worth stating plainly rather than leaving implied: the
default temporal representation **is** lossy for `DATETIME(6)` and `TIMESTAMP(6)`
— sub-millisecond digits are dropped, and no choice of JS type in `effect`
currently avoids that. `dateStrings: true` is the lossless path, and renders
to the column's declared precision identically on both the text and the binary
protocol.

## Testing

264 tests, the majority with no server at all.

`MysqlConnection.in-process.test.ts` scripts a fake server over `net`, because
a real MySQL server is reliable and so cannot produce the cases that matter: a
sequence-id gap, a capability it will never withhold, an ERR where a greeting
belongs, a socket that dies mid-command. It earned its place on the first run
by catching a defect — a server refusing the connection outright (too many
connections, host blocked) sends an ERR instead of its greeting, and that was
being handed to the handshake decoder, which reported a malformed protocol
version and buried the real cause.

`MysqlProtocol`, `MysqlTypes`, `MysqlAuth`, the reply readers, parameter
escaping and error classification are all pure and tested directly against
bytes, which covers the edges a server will not readily produce: signed and
unsigned boundaries, BIGINT past 2^53, truncated fields, invalid UTF-8, the
zero date. The error-classification tests pin that the error number beats the
SQLSTATE class where they disagree — 1213 is a deadlock even though it arrives
under 40001, and whether a retry can help differs between the two.

Integration tests run under `EFFECT_INTEGRATION_TESTS=1` against a `mysql:8.4`
container and cover the client, pool, prepared statements, streaming, types,
the migrator, and the shared core suites (`KeyValueStoreTest`,
`PersistedCacheTest`, `PersistedQueueTest`,
`SqlEventLogServerUnencryptedStorageTest`), which exercises the `mysql:`
dialect branches across `cluster/`, `persistence/` and `eventlog/`.

`pnpm check`, `pnpm jsdocs --check`, `pnpm circular` and `pnpm lint-fix` are
clean.

## Two things I would value a maintainer's view on

- One benchmark is behind. Against `mysql2` this client is ahead on the
  single-row query (1.06×), the transaction (1.04×) and 20 concurrent queries
  (1.04×), and behind on the 100-row read (0.85×). The gap is measured rather
  than guessed: decode is about a ninth of a 100-row query, and a CPU profile
  of that workload is 86% idle with this package under a seventh of the active
  time, so the client is waiting rather than computing. What remains is
  per-row — roughly 0.65µs against `mysql2`'s 0.27µs — and 100 rows is 100
  packets, each handed from the parser to the reply reader through a queue, so
  that handoff is the candidate. Written up in `benchmark/README.md` as a
  hypothesis with a number rather than a finding: an earlier attempt to blame
  per-row Effect steps was measured and disproved.
- It would benefit from a maintainer's read on the `SqlModel` multi-statement
  contract. `SqlModel.ts` compiles `insert …; select … LAST_INSERT_ID()` for the
  `mysql` dialect and destructures `([, results]) => results`; the observable
  shape this client returns was inferred from `mysql2`'s behaviour rather than
  from a written spec, and is pinned by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




