### PR TITLE
fix(sql-pg): support sslmode=prefer|allow with libpq fallback semantics

### DIFF
--- a/.changeset/pg-sslmode-prefer.md
+++ b/.changeset/pg-sslmode-prefer.md
@@ -1,0 +1,12 @@
+---
+"@effect/sql-pg": patch
+---
+
+Support `sslmode=prefer` and `sslmode=allow` in connection URLs with libpq semantics.
+
+Both modes now send `SSLRequest` and upgrade to TLS when the server answers `S`, or continue over the same plaintext socket when it answers `N`, instead of failing configuration with `sslmode "prefer" is not supported`. Cancel requests follow the same negotiation. An explicit `ssl` option still overrides the URL.
+
+```ts
+// Hyperdrive local dev, Neon/Supabase pooler URLs, libpq default, ...
+PgClient.layer({ url: Redacted.make("postgres://user:pw@host/db?sslmode=prefer") })
+```

--- a/packages/sql/pg/src/PgConnection.ts
+++ b/packages/sql/pg/src/PgConnection.ts
@@ -229,8 +229,10 @@ export const PgConnection = Context.Service<PgConnection>("@effect/sql-pg/PgConn
  * session sends `Terminate` and ends the socket.
  *
  * When `ssl` is enabled, a server that rejects `SSLRequest` fails the
- * connection. Unix sockets and custom streams should set `ssl.servername`
- * explicitly.
+ * connection. A URL with `sslmode=prefer` or `sslmode=allow` (and no explicit
+ * `ssl`) is the exception: TLS is attempted first and the session continues
+ * in plaintext when the server answers `N`, as libpq does. Unix sockets and
+ * custom streams should set `ssl.servername` explicitly.
  *
  * @category constructors
  * @since 4.0.0
@@ -1830,8 +1832,11 @@ const sendCancelRequest = (config: ResolvedConfig, pid: number, secret: number):
       if (config.ssl === false) return send()
       socket.once("data", (chunk: Uint8Array) => {
         if (done) return
-        // Never send the cancel secret over a connection the server refused
-        // to upgrade.
+        // `N`: the server declined TLS. With `sslmode=prefer|allow` the
+        // session itself was negotiated the same way, so the cancel request
+        // follows it over plaintext. Otherwise never send the cancel secret
+        // over a connection the server refused to upgrade.
+        if (chunk.length === 1 && chunk[0] === 0x4e && config.sslOptional) return send()
         if (chunk.length !== 1 || chunk[0] !== 0x53) return finish()
         const raw = socket
         raw.off("error", finish)
@@ -2057,6 +2062,9 @@ const connect = (config: ResolvedConfig): Effect.Effect<Session, SqlError> =>
         return failConnect(response.failure, "PgConnection: Invalid SSLRequest response")
       }
       if (response.success === "N") {
+        // libpq `sslmode=prefer`: the server declined the upgrade, so the
+        // startup message goes over the same, still-open plaintext socket.
+        if (config.sslOptional) return startup()
         return failConnect(new Error("The server does not support TLS"), "PgConnection: Server refused TLS")
       }
       const raw = socket
@@ -2117,6 +2125,12 @@ interface ResolvedConfig {
   readonly port: number
   readonly path: string | undefined
   readonly ssl: boolean | ConnectionOptions
+  /**
+   * `true` when the URL asked for `sslmode=prefer` or `sslmode=allow` without
+   * an explicit `ssl`: TLS is attempted and an `N` reply falls back to
+   * plaintext instead of failing the connection.
+   */
+  readonly sslOptional: boolean
   readonly database: string | undefined
   readonly username: string
   readonly password: string | undefined
@@ -2138,7 +2152,7 @@ const configError = (message: string, cause?: unknown): SqlError =>
 const resolveConfig = (options: Config): Effect.Effect<ResolvedConfig, SqlError> =>
   Effect.suspend(() => {
     const parsed: EffectResult.Result<UrlConfig, SqlError> = options.url !== undefined
-      ? parseUrl(Redacted.value(options.url), options.ssl !== undefined)
+      ? parseUrl(Redacted.value(options.url))
       : EffectResult.succeed({})
     if (EffectResult.isFailure(parsed)) return Effect.fail(parsed.failure)
     const url = parsed.success
@@ -2148,11 +2162,14 @@ const resolveConfig = (options: Config): Effect.Effect<ResolvedConfig, SqlError>
     if (username === undefined) {
       return Effect.fail(configError("No username configured"))
     }
+    // An explicit `ssl` wins over the URL outright, including over `prefer`.
+    const sslOptional = options.ssl === undefined && url.ssl === "prefer"
     return Effect.succeed<ResolvedConfig>({
       host,
       port,
       path: options.path ?? (host.startsWith("/") ? `${host}/.s.PGSQL.${port}` : undefined),
-      ssl: options.ssl ?? url.ssl ?? false,
+      ssl: options.ssl ?? (url.ssl === "prefer" ? true : url.ssl ?? false),
+      sslOptional,
       database: options.database ?? url.database,
       username,
       password: options.password !== undefined ? Redacted.value(options.password) : url.password,
@@ -2171,7 +2188,8 @@ interface UrlConfig {
   password?: string | undefined
   applicationName?: string | undefined
   connectTimeout?: Duration.Duration | undefined
-  ssl?: boolean | undefined
+  /** `"prefer"` covers both libpq's `prefer` and `allow`: TLS if offered, plaintext otherwise. */
+  ssl?: boolean | "prefer" | undefined
 }
 
 const decodeComponent = (value: string, what: string): EffectResult.Result<string, SqlError> => {
@@ -2189,7 +2207,7 @@ const parsePort = (value: string, what: string): EffectResult.Result<number, Sql
     : EffectResult.succeed(port)
 }
 
-const parseUrl = (raw: string, hasExplicitSsl: boolean): EffectResult.Result<UrlConfig, SqlError> => {
+const parseUrl = (raw: string): EffectResult.Result<UrlConfig, SqlError> => {
   let url: URL
   try {
     url = new URL(raw)
@@ -2270,12 +2288,14 @@ const parseUrl = (raw: string, hasExplicitSsl: boolean): EffectResult.Result<Url
           case "verify-full":
             config.ssl = true
             break
+          // libpq's default. `allow` (plaintext first, TLS on demand) is
+          // folded into `prefer` (TLS first, plaintext on `N`): both accept
+          // either transport, only the order of attempts differs, and the
+          // server's `N` answer settles it in one round trip.
           case "prefer":
           case "allow":
-            if (hasExplicitSsl) break
-            return EffectResult.fail(
-              configError(`sslmode "${value}" is not supported: set ssl explicitly to true or false`)
-            )
+            config.ssl = "prefer"
+            break
           default:
             return EffectResult.fail(configError(`Unrecognized sslmode in URL: "${value}"`))
         }

--- a/packages/sql/pg/test/PgConnection.in-process.test.ts
+++ b/packages/sql/pg/test/PgConnection.in-process.test.ts
@@ -402,6 +402,137 @@ describe("PgConnection in-process server", () => {
     }
   })
 
+  describe("sslmode=prefer", () => {
+    const sslRequest = Buffer.concat([int32(8), int32(80877103)])
+    const cancelRequest = Buffer.concat([int32(16), int32(80877102), int32(1234), int32(5678)])
+
+    // A server that answers SSLRequest with `reply`, then completes startup
+    // (or, for a cancel connection, closes after the CancelRequest frame).
+    const makeStream = (reply: "S" | "N", cancel: boolean) => {
+      const writes: Array<Buffer> = []
+      const socket: Duplex = new Duplex({
+        read() {},
+        write(chunk: Buffer, _encoding, callback) {
+          writes.push(Buffer.from(chunk))
+          queueMicrotask(() => {
+            if (writes.length === 1) {
+              socket.push(Buffer.from(reply))
+            } else if (cancel) {
+              socket.destroy()
+            } else if (writes.length === 2) {
+              socket.push(Buffer.concat([authenticationOk, backendKeyData, readyForQuery]))
+            }
+          })
+          callback()
+        }
+      })
+      // Registered so the mocked `tls.connect` records whether an upgrade
+      // was attempted; `N` paths must leave it `undefined`.
+      tlsOptions.set(socket, undefined)
+      return { socket, writes }
+    }
+
+    const url = (mode: string) => Redacted.make(`postgres://test@db.example.com/db?sslmode=${mode}`)
+
+    it.effect.each(["prefer", "allow"])(
+      "upgrades to TLS when the server answers S (sslmode=%s)",
+      (mode) =>
+        Effect.gen(function*() {
+          const stream = makeStream("S", false)
+          yield* PgConnection.make({ url: url(mode), stream: () => stream.socket })
+
+          assert.deepStrictEqual(stream.writes[0], sslRequest)
+          const options = tlsOptions.get(stream.socket)
+          assert.isDefined(options)
+          assert.strictEqual(options!.servername, "db.example.com")
+          assert.deepStrictEqual(startupParameters(stream.writes[1]).get("user"), "test")
+        })
+    )
+
+    it.effect.each(["prefer", "allow"])(
+      "continues in plaintext when the server answers N (sslmode=%s)",
+      (mode) =>
+        Effect.gen(function*() {
+          const stream = makeStream("N", false)
+          yield* PgConnection.make({ url: url(mode), stream: () => stream.socket })
+
+          assert.deepStrictEqual(stream.writes[0], sslRequest)
+          assert.isUndefined(tlsOptions.get(stream.socket))
+          assert.strictEqual(stream.writes.length, 2)
+          assert.deepStrictEqual(startupParameters(stream.writes[1]).get("user"), "test")
+        })
+    )
+
+    it.effect("sends the cancel request in plaintext when the server answers N", () =>
+      Effect.gen(function*() {
+        const streams: Array<ReturnType<typeof makeStream>> = []
+        const connection = yield* PgConnection.make({
+          url: url("prefer"),
+          stream: () => {
+            const stream = makeStream("N", streams.length > 0)
+            streams.push(stream)
+            return stream.socket
+          }
+        })
+        yield* connection.interrupt
+
+        assert.strictEqual(streams.length, 2)
+        const cancel = streams[1]
+        assert.deepStrictEqual(cancel.writes, [sslRequest, cancelRequest])
+        assert.isUndefined(tlsOptions.get(cancel.socket))
+      }))
+
+    it.effect("never sends the cancel secret in plaintext when TLS was required", () =>
+      Effect.gen(function*() {
+        const streams: Array<ReturnType<typeof makeStream>> = []
+        const connection = yield* PgConnection.make({
+          url: url("require"),
+          stream: () => {
+            // Session negotiates TLS; the cancel connection is refused it.
+            const stream = makeStream(streams.length > 0 ? "N" : "S", streams.length > 0)
+            streams.push(stream)
+            return stream.socket
+          }
+        })
+        yield* connection.interrupt
+
+        assert.strictEqual(streams.length, 2)
+        assert.deepStrictEqual(streams[1].writes, [sslRequest])
+      }))
+
+    it.effect("explicit ssl: true wins over sslmode=prefer and fails on N", () =>
+      Effect.gen(function*() {
+        const stream = makeStream("N", false)
+        const error = yield* Effect.flip(PgConnection.make({
+          url: url("prefer"),
+          ssl: true,
+          stream: () => stream.socket
+        }))
+        assert.strictEqual(error.reason._tag, "ConnectionError")
+        assert.include(error.reason.message, "refused TLS")
+      }))
+
+    it.effect("explicit ssl: false wins over sslmode=prefer and skips SSLRequest", () =>
+      Effect.gen(function*() {
+        const writes: Array<Buffer> = []
+        const socket: Duplex = new Duplex({
+          read() {},
+          write(chunk: Buffer, _encoding, callback) {
+            writes.push(Buffer.from(chunk))
+            queueMicrotask(() => {
+              if (writes.length === 1) {
+                socket.push(Buffer.concat([authenticationOk, backendKeyData, readyForQuery]))
+              }
+            })
+            callback()
+          }
+        })
+        yield* PgConnection.make({ url: url("prefer"), ssl: false, stream: () => socket })
+        assert.strictEqual(writes.length, 1)
+        assert.deepStrictEqual(startupParameters(writes[0]).get("user"), "test")
+      }))
+  })
+
   it.live("preserves an ErrorResponse returned for SSLRequest", () =>
     Effect.scoped(Effect.gen(function*() {
       const { port } = yield* withTcpServer((socket) => {

--- a/packages/sql/pg/test/PgConnection.test.ts
+++ b/packages/sql/pg/test/PgConnection.test.ts
@@ -1,24 +1,40 @@
 import { PgConnection } from "@effect/sql-pg"
 import { assert, describe, it } from "@effect/vitest"
 import { Effect, Redacted } from "effect"
+import { Duplex } from "node:stream"
 
 describe("PgConnection config", () => {
-  it.effect("rejects sslmode=prefer in a URL", () =>
-    Effect.gen(function*() {
-      const error = yield* Effect.flip(PgConnection.make({
-        url: Redacted.make("postgres://user@localhost/db?sslmode=prefer")
-      }))
-      assert.strictEqual(error.reason._tag, "ConnectionError")
-      assert.include(error.reason.message, "sslmode")
-    }))
+  it.effect.each(["prefer", "allow"])(
+    "accepts sslmode=%s in a URL and sends SSLRequest",
+    (mode) =>
+      Effect.gen(function*() {
+        const writes: Array<Buffer> = []
+        const error = yield* Effect.flip(PgConnection.make({
+          url: Redacted.make(`postgres://user@localhost/db?sslmode=${mode}`),
+          stream: () =>
+            new Duplex({
+              read() {},
+              write(chunk: Buffer, _encoding, callback) {
+                writes.push(Buffer.from(chunk))
+                queueMicrotask(() => this.destroy(new Error("test connection")))
+                callback()
+              }
+            })
+        }))
+        assert.strictEqual(error.reason._tag, "ConnectionError")
+        assert.strictEqual(error.reason.message, "PgConnection: Failed to connect")
+        // 8-byte SSLRequest (code 80877103), not a StartupMessage.
+        assert.strictEqual(writes[0]?.toString("hex"), "0000000804d2162f")
+      })
+  )
 
-  it.effect("rejects sslmode=allow in a URL", () =>
+  it.effect("rejects an unrecognized sslmode in a URL", () =>
     Effect.gen(function*() {
       const error = yield* Effect.flip(PgConnection.make({
-        url: Redacted.make("postgresql://user@localhost/db?sslmode=allow")
+        url: Redacted.make("postgres://user@localhost/db?sslmode=maybe")
       }))
       assert.strictEqual(error.reason._tag, "ConnectionError")
-      assert.include(error.reason.message, "sslmode")
+      assert.include(error.reason.message, "Unrecognized sslmode")
     }))
 
   it.effect("lets explicit ssl override sslmode=prefer in a URL", () =>


### PR DESCRIPTION
Closes #8198

`PgConnection` currently rejects `sslmode=prefer` and `sslmode=allow` at config time unless `ssl` is set explicitly. libpq's default is `prefer`, so these URLs are common (Cloudflare Hyperdrive local passthrough, managed poolers, `psql`-style connection strings that used to work with `pg`).

This implements libpq's negotiation for both modes: send `SSLRequest`, upgrade on `S`, and continue the startup over the same plaintext socket on `N`. The cancel-request connection follows the same rule so a plaintext session can still be interrupted. An explicit `ssl: true | false | ConnectionOptions` still overrides the URL, including `prefer`.

```ts
// before: SqlError `sslmode "prefer" is not supported: set ssl explicitly to true or false`
// after:  TLS if the server offers it, plaintext otherwise
PgClient.layer({ url: Redacted.make("postgres://user:pw@host/db?sslmode=prefer") })
```

`allow` is folded into `prefer`. libpq tries plaintext first for `allow` and only falls back to TLS if the server's `pg_hba.conf` rejects the non-SSL session, which would require a full second connection attempt after an auth failure. Both modes accept either transport; only the order of attempts differs, and the server's one-byte answer to `SSLRequest` settles it in one round trip.

Tests (in-process fake server, mocked `tls.connect` like the existing SNI cases): `S` upgrades with the right `servername`, `N` continues in plaintext with no `tls.connect` call, cancel goes plaintext on `N` under `prefer` but is dropped under `require`, and explicit `ssl: true` / `ssl: false` still win over the URL.
