### PR TITLE
Support TLS fallback for sql-pg prefer and allow modes

### DIFF
--- a/.changeset/pg-sslmode-compatibility.md
+++ b/.changeset/pg-sslmode-compatibility.md
@@ -2,4 +2,4 @@
 "@effect/sql-pg": patch
 ---
 
-Support `sslmode=prefer` and `sslmode=allow` by trying TLS first, then plaintext if the server declines `SSLRequest`. Unlike libpq, `allow` also tries TLS first. Explicit `ssl` overrides and certificate verification are unchanged. Cancellation never downgrades a TLS session to plaintext.
+Support `sslmode=prefer` and `sslmode=allow` by trying TLS first, then plaintext if the server declines `SSLRequest`. Unlike libpq, `allow` also tries TLS first. Explicit `ssl` overrides and certificate verification are unchanged. TLS handshake and certificate failures remain fatal. Cancellation never downgrades a TLS session to plaintext.

--- a/.changeset/pg-sslmode-compatibility.md
+++ b/.changeset/pg-sslmode-compatibility.md
@@ -2,4 +2,4 @@
 "@effect/sql-pg": patch
 ---
 
-Support `sslmode=prefer` and `sslmode=allow` in connection URLs as aliases for `sslmode=require`, without plaintext fallback.
+Support `sslmode=prefer` and `sslmode=allow` by trying TLS first, then plaintext if the server declines `SSLRequest`. Unlike libpq, `allow` also tries TLS first. Explicit `ssl` overrides and certificate verification are unchanged. Cancellation never downgrades a TLS session to plaintext.

--- a/.changeset/pg-sslmode-compatibility.md
+++ b/.changeset/pg-sslmode-compatibility.md
@@ -2,4 +2,4 @@
 "@effect/sql-pg": patch
 ---
 
-Accept connection URLs containing `sslmode=prefer` or `sslmode=allow` by enabling TLS. These modes use the same behavior as `sslmode=require`, without libpq fallback between TLS and plaintext. Explicit `ssl` options continue to override the URL mode.
+Support `sslmode=prefer` and `sslmode=allow` in connection URLs as aliases for `sslmode=require`, without plaintext fallback.

--- a/.changeset/pg-sslmode-compatibility.md
+++ b/.changeset/pg-sslmode-compatibility.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-pg": patch
+---
+
+Accept connection URLs containing `sslmode=prefer` or `sslmode=allow` by enabling TLS. These modes use the same behavior as `sslmode=require`, without libpq fallback between TLS and plaintext. Explicit `ssl` options continue to override the URL mode.

--- a/packages/sql/pg/src/PgConnection.ts
+++ b/packages/sql/pg/src/PgConnection.ts
@@ -233,6 +233,7 @@ export const PgConnection = Context.Service<PgConnection>("@effect/sql-pg/PgConn
  * backend sends `ReadyForQuery`. When the scope closes, the
  * session sends `Terminate` and ends the socket.
  *
+ * Use `sslmode=require` or explicit `ssl: true` to require encryption.
  * Unix sockets and custom streams should set `ssl.servername` explicitly.
  *
  * @category constructors

--- a/packages/sql/pg/src/PgConnection.ts
+++ b/packages/sql/pg/src/PgConnection.ts
@@ -66,6 +66,11 @@ export type TypeId = "~@effect/sql-pg/PgConnection"
  * socket path, while a `host` beginning with `/` is treated as a socket
  * directory and expands to `${host}/.s.PGSQL.${port}`.
  *
+ * URL modes `sslmode=prefer` and `sslmode=allow` enable TLS, like
+ * `sslmode=require`. They do not implement libpq's fallback between TLS and
+ * plaintext: a server that refuses TLS fails the connection. Explicit `ssl`
+ * options override the URL mode; use `ssl: false` to connect in plaintext.
+ *
  * Prepared statements are enabled by default and limited by
  * `preparedStatementCacheSize`. Disable them for statement-mode poolers or
  * workloads that generate unique SQL. Streams always use unnamed statements.
@@ -2138,7 +2143,7 @@ const configError = (message: string, cause?: unknown): SqlError =>
 const resolveConfig = (options: Config): Effect.Effect<ResolvedConfig, SqlError> =>
   Effect.suspend(() => {
     const parsed: EffectResult.Result<UrlConfig, SqlError> = options.url !== undefined
-      ? parseUrl(Redacted.value(options.url), options.ssl !== undefined)
+      ? parseUrl(Redacted.value(options.url))
       : EffectResult.succeed({})
     if (EffectResult.isFailure(parsed)) return Effect.fail(parsed.failure)
     const url = parsed.success
@@ -2189,7 +2194,7 @@ const parsePort = (value: string, what: string): EffectResult.Result<number, Sql
     : EffectResult.succeed(port)
 }
 
-const parseUrl = (raw: string, hasExplicitSsl: boolean): EffectResult.Result<UrlConfig, SqlError> => {
+const parseUrl = (raw: string): EffectResult.Result<UrlConfig, SqlError> => {
   let url: URL
   try {
     url = new URL(raw)
@@ -2268,14 +2273,10 @@ const parseUrl = (raw: string, hasExplicitSsl: boolean): EffectResult.Result<Url
           case "require":
           case "verify-ca":
           case "verify-full":
-            config.ssl = true
-            break
           case "prefer":
           case "allow":
-            if (hasExplicitSsl) break
-            return EffectResult.fail(
-              configError(`sslmode "${value}" is not supported: set ssl explicitly to true or false`)
-            )
+            config.ssl = true
+            break
           default:
             return EffectResult.fail(configError(`Unrecognized sslmode in URL: "${value}"`))
         }

--- a/packages/sql/pg/src/PgConnection.ts
+++ b/packages/sql/pg/src/PgConnection.ts
@@ -66,8 +66,10 @@ export type TypeId = "~@effect/sql-pg/PgConnection"
  * socket path, while a `host` beginning with `/` is treated as a socket
  * directory and expands to `${host}/.s.PGSQL.${port}`.
  *
- * URL modes `sslmode=prefer` and `sslmode=allow` are aliases for
- * `sslmode=require`, without plaintext fallback.
+ * URL modes `sslmode=prefer` and `sslmode=allow` try TLS first, falling back
+ * to plaintext only when the server answers `SSLRequest` with `N`. Unlike
+ * libpq, `allow` also tries TLS first. Certificate verification stays enabled
+ * unless explicitly disabled through `ssl` options.
  *
  * Prepared statements are enabled by default and limited by
  * `preparedStatementCacheSize`. Disable them for statement-mode poolers or
@@ -231,9 +233,7 @@ export const PgConnection = Context.Service<PgConnection>("@effect/sql-pg/PgConn
  * backend sends `ReadyForQuery`. When the scope closes, the
  * session sends `Terminate` and ends the socket.
  *
- * When `ssl` is enabled, a server that rejects `SSLRequest` fails the
- * connection. Unix sockets and custom streams should set `ssl.servername`
- * explicitly.
+ * Unix sockets and custom streams should set `ssl.servername` explicitly.
  *
  * @category constructors
  * @since 4.0.0
@@ -265,6 +265,7 @@ export const make = (options: Config): Effect.Effect<PgConnection, SqlError, Sco
 
 interface Session {
   readonly socket: Duplex
+  readonly encrypted: boolean
   readonly parser: PgProtocol.Parser<unknown>
   readonly processId: number
   readonly secretKey: number
@@ -666,7 +667,7 @@ class PgConnectionImpl implements PgConnection {
   /** Sends a `CancelRequest` for this session on a side connection. */
   readonly cancel: Effect.Effect<void> = Effect.suspend(() => {
     if (this.deadWith !== undefined) return Effect.void
-    return sendCancelRequest(this.resolved, this.session.processId, this.session.secretKey)
+    return sendCancelRequest(this.resolved, this.session)
   })
 
   readonly pin: Effect.Effect<PgConnection, never, Scope.Scope> = Effect.suspend(() => {
@@ -1811,7 +1812,7 @@ const listenChannel = (
     })
   )
 
-const sendCancelRequest = (config: ResolvedConfig, pid: number, secret: number): Effect.Effect<void> =>
+const sendCancelRequest = (config: ResolvedConfig, session: Session): Effect.Effect<void> =>
   Effect.callback<void>((resume) => {
     let done = false
     let socket: Duplex
@@ -1823,7 +1824,7 @@ const sendCancelRequest = (config: ResolvedConfig, pid: number, secret: number):
       socket?.destroy()
       resume(Effect.void)
     }
-    const frame = PgProtocol.encodeCancelRequest({ pid, secret })
+    const frame = PgProtocol.encodeCancelRequest({ pid: session.processId, secret: session.secretKey })
     // After the frame is written the server processes the request and closes
     // the connection, which lands in the `close` handler.
     const send = (): void => {
@@ -1833,8 +1834,8 @@ const sendCancelRequest = (config: ResolvedConfig, pid: number, secret: number):
       if (config.ssl === false) return send()
       socket.once("data", (chunk: Uint8Array) => {
         if (done) return
-        // Never send the cancel secret over a connection the server refused
-        // to upgrade.
+        // A TLS session's cancel secret must stay encrypted.
+        if (chunk.length === 1 && chunk[0] === 0x4e && config.sslOptional && !session.encrypted) return send()
         if (chunk.length !== 1 || chunk[0] !== 0x53) return finish()
         const raw = socket
         raw.off("error", finish)
@@ -1873,6 +1874,7 @@ const connect = (config: ResolvedConfig): Effect.Effect<Session, SqlError> =>
   Effect.callback<Session, SqlError>((resume) => {
     let done = false
     let socket: Duplex
+    let encrypted = false
     let parser: PgProtocol.Parser<unknown> | undefined
     let sslErrorParser: PgProtocol.Parser | undefined
     let scram: PgAuth.ScramState | undefined
@@ -1994,7 +1996,7 @@ const connect = (config: ResolvedConfig): Effect.Effect<Session, SqlError> =>
           socket.off("error", onError)
           socket.off("close", onClose)
           socket.on("error", ignoreError)
-          resume(Effect.succeed({ socket, parser: parser!, processId, secretKey }))
+          resume(Effect.succeed({ socket, encrypted, parser: parser!, processId, secretKey }))
           return
         default:
           return failConnect(
@@ -2060,6 +2062,7 @@ const connect = (config: ResolvedConfig): Effect.Effect<Session, SqlError> =>
         return failConnect(response.failure, "PgConnection: Invalid SSLRequest response")
       }
       if (response.success === "N") {
+        if (config.sslOptional) return startup()
         return failConnect(new Error("The server does not support TLS"), "PgConnection: Server refused TLS")
       }
       const raw = socket
@@ -2073,7 +2076,10 @@ const connect = (config: ResolvedConfig): Effect.Effect<Session, SqlError> =>
       })
       socket.on("error", onError)
       socket.on("close", onClose)
-      socket.once("secureConnect", startup)
+      socket.once("secureConnect", () => {
+        encrypted = true
+        startup()
+      })
     }
 
     const begin = (): void => {
@@ -2120,6 +2126,7 @@ interface ResolvedConfig {
   readonly port: number
   readonly path: string | undefined
   readonly ssl: boolean | ConnectionOptions
+  readonly sslOptional: boolean
   readonly database: string | undefined
   readonly username: string
   readonly password: string | undefined
@@ -2155,7 +2162,8 @@ const resolveConfig = (options: Config): Effect.Effect<ResolvedConfig, SqlError>
       host,
       port,
       path: options.path ?? (host.startsWith("/") ? `${host}/.s.PGSQL.${port}` : undefined),
-      ssl: options.ssl ?? url.ssl ?? false,
+      ssl: options.ssl ?? (url.ssl === "prefer" ? true : url.ssl ?? false),
+      sslOptional: options.ssl === undefined && url.ssl === "prefer",
       database: options.database ?? url.database,
       username,
       password: options.password !== undefined ? Redacted.value(options.password) : url.password,
@@ -2174,7 +2182,7 @@ interface UrlConfig {
   password?: string | undefined
   applicationName?: string | undefined
   connectTimeout?: Duration.Duration | undefined
-  ssl?: boolean | undefined
+  ssl?: boolean | "prefer" | undefined
 }
 
 const decodeComponent = (value: string, what: string): EffectResult.Result<string, SqlError> => {
@@ -2271,9 +2279,11 @@ const parseUrl = (raw: string): EffectResult.Result<UrlConfig, SqlError> => {
           case "require":
           case "verify-ca":
           case "verify-full":
+            config.ssl = true
+            break
           case "prefer":
           case "allow":
-            config.ssl = true
+            config.ssl = "prefer"
             break
           default:
             return EffectResult.fail(configError(`Unrecognized sslmode in URL: "${value}"`))

--- a/packages/sql/pg/src/PgConnection.ts
+++ b/packages/sql/pg/src/PgConnection.ts
@@ -66,10 +66,8 @@ export type TypeId = "~@effect/sql-pg/PgConnection"
  * socket path, while a `host` beginning with `/` is treated as a socket
  * directory and expands to `${host}/.s.PGSQL.${port}`.
  *
- * URL modes `sslmode=prefer` and `sslmode=allow` enable TLS, like
- * `sslmode=require`. They do not implement libpq's fallback between TLS and
- * plaintext: a server that refuses TLS fails the connection. Explicit `ssl`
- * options override the URL mode; use `ssl: false` to connect in plaintext.
+ * URL modes `sslmode=prefer` and `sslmode=allow` are aliases for
+ * `sslmode=require`, without plaintext fallback.
  *
  * Prepared statements are enabled by default and limited by
  * `preparedStatementCacheSize`. Disable them for statement-mode poolers or

--- a/packages/sql/pg/test/PgConnection.in-process.test.ts
+++ b/packages/sql/pg/test/PgConnection.in-process.test.ts
@@ -455,7 +455,6 @@ describe("PgConnection in-process server", () => {
       })
   )
 
-  // These aliases use the existing strict TLS behavior, without libpq fallback.
   it.effect.each(["require", "prefer", "allow"])(
     "sslmode=%s fails when the server refuses TLS",
     (sslmode) =>

--- a/packages/sql/pg/test/PgConnection.in-process.test.ts
+++ b/packages/sql/pg/test/PgConnection.in-process.test.ts
@@ -12,8 +12,7 @@ import { vi } from "vitest"
 
 const tlsOptions = new WeakMap<Duplex, Tls.ConnectionOptions | undefined>()
 
-// Only simulate TLS for streams registered by the SNI tests. Other connections
-// retain the native TLS implementation, including tests running concurrently.
+// Only simulate TLS for registered streams; other connections use native TLS.
 vi.mock("node:tls", async (importOriginal) => {
   const original = await importOriginal<typeof Tls>()
   return {
@@ -54,6 +53,31 @@ const authentication = (method: number, payload: Uint8Array = Buffer.alloc(0)): 
 const authenticationOk = authentication(0)
 const backendKeyData = backendMessage("K", Buffer.concat([int32(1234), int32(5678)]))
 const readyForQuery = backendMessage("Z", Buffer.from("I"))
+const sslRequest = Buffer.concat([int32(8), int32(80877103)])
+const cancelRequest = Buffer.concat([int32(16), int32(80877102), int32(1234), int32(5678)])
+
+const makeSslStream = (reply: "S" | "N", cancel: boolean) => {
+  const writes: Array<Buffer> = []
+  const socket: Duplex = new Duplex({
+    read() {},
+    write(chunk: Buffer, _encoding, callback) {
+      writes.push(Buffer.from(chunk))
+      queueMicrotask(() => {
+        if (writes.length === 1) {
+          socket.push(Buffer.from(reply))
+        } else if (cancel) {
+          socket.destroy()
+        } else if (writes.length === 2) {
+          socket.push(Buffer.concat([authenticationOk, backendKeyData, readyForQuery]))
+        }
+      })
+      callback()
+    }
+  })
+  tlsOptions.set(socket, undefined)
+  return { socket, writes }
+}
+
 const emptyQueryResult = Buffer.concat([
   backendMessage("1", Buffer.alloc(0)),
   backendMessage("2", Buffer.alloc(0)),
@@ -312,28 +336,6 @@ describe("PgConnection in-process server", () => {
     }))
 
   describe("TLS servername", () => {
-    const makeStream = (cancel: boolean) => {
-      const writes: Array<Buffer> = []
-      const socket: Duplex = new Duplex({
-        read() {},
-        write(chunk: Buffer, _encoding, callback) {
-          writes.push(Buffer.from(chunk))
-          queueMicrotask(() => {
-            if (writes.length === 1) {
-              socket.push(Buffer.from("S"))
-            } else if (cancel) {
-              socket.destroy()
-            } else if (writes.length === 2) {
-              socket.push(Buffer.concat([authenticationOk, backendKeyData, readyForQuery]))
-            }
-          })
-          callback()
-        }
-      })
-      tlsOptions.set(socket, undefined)
-      return { socket, writes }
-    }
-
     const cases: ReadonlyArray<{
       readonly name: string
       readonly config: PgConnection.Config
@@ -350,15 +352,15 @@ describe("PgConnection in-process server", () => {
         config: { url: Redacted.make("postgres://test@db.example.com/db?sslmode=require") },
         servername: "db.example.com"
       },
+      {
+        name: "ssl=true overrides sslmode=disable",
+        config: { url: Redacted.make("postgres://test@db.example.com/db?sslmode=disable"), ssl: true },
+        servername: "db.example.com"
+      },
       ...["prefer", "allow"].flatMap((sslmode) => [
         {
           name: `sslmode=${sslmode} enables TLS`,
           config: { url: Redacted.make(`postgresql://test@db.example.com/db?sslmode=${sslmode}`) },
-          servername: "db.example.com"
-        },
-        {
-          name: `ssl=true overrides sslmode=${sslmode}`,
-          config: { url: Redacted.make(`postgres://test@db.example.com/db?sslmode=${sslmode}`), ssl: true },
           servername: "db.example.com"
         },
         {
@@ -388,12 +390,12 @@ describe("PgConnection in-process server", () => {
       describe(path, () => {
         it.effect.each(cases)("$name", ({ config, servername }) =>
           Effect.gen(function*() {
-            const streams: Array<ReturnType<typeof makeStream>> = []
+            const streams: Array<ReturnType<typeof makeSslStream>> = []
             const connection = yield* PgConnection.make({
               username: "test",
               ...config,
               stream: () => {
-                const stream = makeStream(streams.length > 0)
+                const stream = makeSslStream("S", streams.length > 0)
                 streams.push(stream)
                 return stream.socket
               }
@@ -404,12 +406,9 @@ describe("PgConnection in-process server", () => {
 
             assert.strictEqual(streams.length, path === "cancel" ? 2 : 1)
             const stream = streams[path === "cancel" ? 1 : 0]
-            assert.deepStrictEqual(stream.writes[0], Buffer.concat([int32(8), int32(80877103)]))
+            assert.deepStrictEqual(stream.writes[0], sslRequest)
             if (path === "cancel") {
-              assert.deepStrictEqual(
-                stream.writes[1],
-                Buffer.concat([int32(16), int32(80877102), int32(1234), int32(5678)])
-              )
+              assert.deepStrictEqual(stream.writes[1], cancelRequest)
             } else {
               assert.strictEqual(stream.writes[1].readInt32BE(4), 196608)
               assert.strictEqual(startupParameters(stream.writes[1]).get("user"), "test")
@@ -419,6 +418,8 @@ describe("PgConnection in-process server", () => {
             assert.strictEqual(options!.servername, servername)
             if (typeof config.ssl === "object") {
               assert.strictEqual(options!.rejectUnauthorized, config.ssl.rejectUnauthorized)
+            } else {
+              assert.notStrictEqual(options!.rejectUnauthorized, false)
             }
           }))
       })
@@ -455,7 +456,7 @@ describe("PgConnection in-process server", () => {
       })
   )
 
-  it.effect.each(["require", "prefer", "allow"])(
+  it.effect.each(["require", "verify-ca", "verify-full"])(
     "sslmode=%s fails when the server refuses TLS",
     (sslmode) =>
       Effect.gen(function*() {
@@ -479,6 +480,98 @@ describe("PgConnection in-process server", () => {
         assert.isTrue(socket.destroyed)
       })
   )
+
+  describe("TLS fallback", () => {
+    it.effect.each(["prefer", "allow"])("sslmode=%s starts in plaintext after N", (sslmode) =>
+      Effect.gen(function*() {
+        const stream = makeSslStream("N", false)
+        let connections = 0
+        yield* PgConnection.make({
+          url: Redacted.make(`postgres://test@db.example.com/db?sslmode=${sslmode}`),
+          stream: () => {
+            connections++
+            return stream.socket
+          }
+        })
+
+        assert.strictEqual(connections, 1)
+        assert.strictEqual(stream.writes.length, 2)
+        assert.deepStrictEqual(stream.writes[0], sslRequest)
+        assert.strictEqual(stream.writes[1].readInt32BE(4), 196608)
+        assert.strictEqual(startupParameters(stream.writes[1]).get("user"), "test")
+        assert.isUndefined(tlsOptions.get(stream.socket))
+      }))
+
+    it.effect.each(["prefer", "allow"])(
+      "sslmode=%s allows plaintext cancellation for a plaintext session",
+      (sslmode) =>
+        Effect.gen(function*() {
+          const streams: Array<ReturnType<typeof makeSslStream>> = []
+          const connection = yield* PgConnection.make({
+            url: Redacted.make(`postgres://test@db.example.com/db?sslmode=${sslmode}`),
+            stream: () => {
+              const stream = makeSslStream("N", streams.length > 0)
+              streams.push(stream)
+              return stream.socket
+            }
+          })
+          yield* connection.interrupt
+
+          assert.strictEqual(streams.length, 2)
+          assert.isUndefined(tlsOptions.get(streams[0].socket))
+          assert.deepStrictEqual(streams[0].writes[0], sslRequest)
+          assert.strictEqual(streams[0].writes[1].readInt32BE(4), 196608)
+          assert.deepStrictEqual(streams[1].writes, [sslRequest, cancelRequest])
+          assert.isUndefined(tlsOptions.get(streams[1].socket))
+          assert.isTrue(streams[1].socket.destroyed)
+        })
+    )
+
+    it.effect.each(["prefer", "allow", "require"])(
+      "sslmode=%s refuses plaintext cancellation for a TLS session",
+      (sslmode) =>
+        Effect.gen(function*() {
+          const streams: Array<ReturnType<typeof makeSslStream>> = []
+          const connection = yield* PgConnection.make({
+            url: Redacted.make(`postgres://test@db.example.com/db?sslmode=${sslmode}`),
+            stream: () => {
+              const cancel = streams.length > 0
+              const stream = makeSslStream(cancel ? "N" : "S", cancel)
+              streams.push(stream)
+              return stream.socket
+            }
+          })
+          yield* connection.interrupt
+
+          assert.strictEqual(streams.length, 2)
+          assert.isDefined(tlsOptions.get(streams[0].socket))
+          assert.deepStrictEqual(streams[1].writes, [sslRequest])
+          assert.isUndefined(tlsOptions.get(streams[1].socket))
+          assert.isTrue(streams[1].socket.destroyed)
+        })
+    )
+
+    for (const sslmode of ["prefer", "allow"]) {
+      it.effect.each([true, { rejectUnauthorized: false }] as const)(
+        `explicit ssl=%j prevents sslmode=${sslmode} fallback`,
+        (ssl) =>
+          Effect.gen(function*() {
+            const stream = makeSslStream("N", false)
+            const error = yield* Effect.flip(PgConnection.make({
+              url: Redacted.make(`postgres://test@db.example.com/db?sslmode=${sslmode}`),
+              ssl,
+              stream: () => stream.socket
+            }))
+
+            assert.deepStrictEqual(stream.writes, [sslRequest])
+            assert.strictEqual(error.reason._tag, "ConnectionError")
+            assert.strictEqual(error.reason.message, "PgConnection: Server refused TLS")
+            assert.isUndefined(tlsOptions.get(stream.socket))
+            assert.isTrue(stream.socket.destroyed)
+          })
+      )
+    }
+  })
 
   it.live("preserves an ErrorResponse returned for SSLRequest", () =>
     Effect.scoped(Effect.gen(function*() {

--- a/packages/sql/pg/test/PgConnection.in-process.test.ts
+++ b/packages/sql/pg/test/PgConnection.in-process.test.ts
@@ -350,6 +350,26 @@ describe("PgConnection in-process server", () => {
         config: { url: Redacted.make("postgres://test@db.example.com/db?sslmode=require") },
         servername: "db.example.com"
       },
+      ...["prefer", "allow"].flatMap((sslmode) => [
+        {
+          name: `sslmode=${sslmode} enables TLS`,
+          config: { url: Redacted.make(`postgresql://test@db.example.com/db?sslmode=${sslmode}`) },
+          servername: "db.example.com"
+        },
+        {
+          name: `ssl=true overrides sslmode=${sslmode}`,
+          config: { url: Redacted.make(`postgres://test@db.example.com/db?sslmode=${sslmode}`), ssl: true },
+          servername: "db.example.com"
+        },
+        {
+          name: `SSL options override sslmode=${sslmode}`,
+          config: {
+            url: Redacted.make(`postgres://test@db.example.com/db?sslmode=${sslmode}`),
+            ssl: { servername: "routing.example.com", rejectUnauthorized: false }
+          },
+          servername: "routing.example.com"
+        }
+      ]),
       { name: "IPv4 host", config: { host: "127.0.0.1", ssl: true }, servername: undefined },
       { name: "IPv6 host", config: { host: "::1", ssl: true }, servername: undefined },
       ...["db.example.com", "127.0.0.1", "::1"].map((host) => ({
@@ -390,6 +410,9 @@ describe("PgConnection in-process server", () => {
                 stream.writes[1],
                 Buffer.concat([int32(16), int32(80877102), int32(1234), int32(5678)])
               )
+            } else {
+              assert.strictEqual(stream.writes[1].readInt32BE(4), 196608)
+              assert.strictEqual(startupParameters(stream.writes[1]).get("user"), "test")
             }
             const options = tlsOptions.get(stream.socket)
             assert.isDefined(options)
@@ -401,6 +424,62 @@ describe("PgConnection in-process server", () => {
       })
     }
   })
+
+  it.effect.each(["prefer", "allow"])(
+    "ssl=false overrides sslmode=%s with plaintext startup",
+    (sslmode) =>
+      Effect.gen(function*() {
+        const writes: Array<Buffer> = []
+        const socket: Duplex = new Duplex({
+          read() {},
+          write(chunk: Buffer, _encoding, callback) {
+            writes.push(Buffer.from(chunk))
+            if (writes.length === 1) {
+              queueMicrotask(() => socket.push(Buffer.concat([authenticationOk, backendKeyData, readyForQuery])))
+            }
+            callback()
+          }
+        })
+        tlsOptions.set(socket, undefined)
+
+        yield* PgConnection.make({
+          url: Redacted.make(`postgresql://test@db.example.com/db?sslmode=${sslmode}`),
+          ssl: false,
+          stream: () => socket
+        })
+
+        assert.strictEqual(writes.length, 1)
+        assert.strictEqual(writes[0].readInt32BE(4), 196608)
+        assert.strictEqual(startupParameters(writes[0]).get("user"), "test")
+        assert.isUndefined(tlsOptions.get(socket))
+      })
+  )
+
+  // These aliases use the existing strict TLS behavior, without libpq fallback.
+  it.effect.each(["require", "prefer", "allow"])(
+    "sslmode=%s fails when the server refuses TLS",
+    (sslmode) =>
+      Effect.gen(function*() {
+        const writes: Array<Buffer> = []
+        const socket: Duplex = new Duplex({
+          read() {},
+          write(chunk: Buffer, _encoding, callback) {
+            writes.push(Buffer.from(chunk))
+            queueMicrotask(() => socket.push(Buffer.from("N")))
+            callback()
+          }
+        })
+        const error = yield* Effect.flip(PgConnection.make({
+          url: Redacted.make(`postgres://test@db.example.com/db?sslmode=${sslmode}`),
+          stream: () => socket
+        }))
+
+        assert.deepStrictEqual(writes, [Buffer.concat([int32(8), int32(80877103)])])
+        assert.strictEqual(error.reason._tag, "ConnectionError")
+        assert.strictEqual(error.reason.message, "PgConnection: Server refused TLS")
+        assert.isTrue(socket.destroyed)
+      })
+  )
 
   it.live("preserves an ErrorResponse returned for SSLRequest", () =>
     Effect.scoped(Effect.gen(function*() {

--- a/packages/sql/pg/test/PgConnection.test.ts
+++ b/packages/sql/pg/test/PgConnection.test.ts
@@ -3,30 +3,11 @@ import { assert, describe, it } from "@effect/vitest"
 import { Effect, Redacted } from "effect"
 
 describe("PgConnection config", () => {
-  it.effect("rejects sslmode=prefer in a URL", () =>
-    Effect.gen(function*() {
-      const error = yield* Effect.flip(PgConnection.make({
-        url: Redacted.make("postgres://user@localhost/db?sslmode=prefer")
-      }))
-      assert.strictEqual(error.reason._tag, "ConnectionError")
-      assert.include(error.reason.message, "sslmode")
-    }))
-
-  it.effect("rejects sslmode=allow in a URL", () =>
-    Effect.gen(function*() {
-      const error = yield* Effect.flip(PgConnection.make({
-        url: Redacted.make("postgresql://user@localhost/db?sslmode=allow")
-      }))
-      assert.strictEqual(error.reason._tag, "ConnectionError")
-      assert.include(error.reason.message, "sslmode")
-    }))
-
-  it.effect("lets explicit ssl override sslmode=prefer in a URL", () =>
+  it.effect.each(["prefer", "allow"])("accepts sslmode=%s in a URL", (sslmode) =>
     Effect.gen(function*() {
       let connected = false
       const error = yield* Effect.flip(PgConnection.make({
-        url: Redacted.make("postgres://user@localhost/db?sslmode=prefer"),
-        ssl: false,
+        url: Redacted.make(`postgres://user@localhost/db?sslmode=${sslmode}`),
         stream: () => {
           connected = true
           throw new Error("test connection")
@@ -35,6 +16,21 @@ describe("PgConnection config", () => {
       assert.isTrue(connected)
       assert.strictEqual(error.reason._tag, "ConnectionError")
       assert.strictEqual(error.reason.message, "PgConnection: Failed to connect")
+    }))
+
+  it.effect("rejects an unrecognized sslmode before connecting", () =>
+    Effect.gen(function*() {
+      let connected = false
+      const error = yield* Effect.flip(PgConnection.make({
+        url: Redacted.make("postgresql://user@localhost/db?sslmode=invalid"),
+        stream: () => {
+          connected = true
+          throw new Error("test connection")
+        }
+      }))
+      assert.isFalse(connected)
+      assert.strictEqual(error.reason._tag, "ConnectionError")
+      assert.strictEqual(error.reason.message, "PgConnection: Unrecognized sslmode in URL: \"invalid\"")
     }))
 
   it.effect("rejects a non-postgres URL protocol", () =>


### PR DESCRIPTION
Connection URLs using `sslmode=prefer` or `sslmode=allow` now try TLS first and continue on the same plaintext socket if the server answers `SSLRequest` with `N`. Both modes use TLS-first ordering; libpq's `allow` tries plaintext first.

Cancellation tracks the session's negotiated transport: plaintext sessions may fall back on cancellation, but TLS sessions never send their cancel secret in plaintext. Explicit `ssl` overrides, certificate verification, and SNI behavior are preserved. TLS or certificate errors do not trigger fallback.

Negotiation and test coverage are adapted from Sam Goodwin's [#8199](https://github.com/Effect-TS/effect/pull/8199), with an additional guard against cancellation downgrade. The changeset and API docs describe the behavior.

Validation (all pnpm commands run through `nix develop -c`):

- Full sql-pg suite, including container integration tests: 355 passed; two setup timeouts left 21 tests unrun. Retrying the two affected files with `--maxWorkers=1` passed all 37 tests.
- `pnpm check`, `pnpm lint-fix`, `pnpm lint`, and `pnpm jsdocs --check`: passed.
- `git diff --check`: passed.

Integration tests used `EFFECT_INTEGRATION_TESTS=1`, the local Podman socket, and `TESTCONTAINERS_RYUK_DISABLED=true`.

Closes EFF-1357
Closes #8198
