### PR TITLE
fix(RcRef): keep idleTimeToLive when the value is 0

### DIFF
--- a/.changeset/fix-rcref-idle-ttl-zero.md
+++ b/.changeset/fix-rcref-idle-ttl-zero.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Fix `RcRef.make` to treat `idleTimeToLive: 0` like `Duration.zero` and `"0 millis"`. Release runs in a forked fiber and is not awaited by the scope releasing the last reference. Omitting `idleTimeToLive` still releases the resource within that scope and awaits completion.
+Fix `RcRef.make` to treat `idleTimeToLive: 0` like `Duration.zero` and `"0 millis"` instead of an omitted option.

--- a/.changeset/fix-rcref-idle-ttl-zero.md
+++ b/.changeset/fix-rcref-idle-ttl-zero.md
@@ -2,4 +2,4 @@
 "effect": patch
 ---
 
-Keep `RcRef.make({ idleTimeToLive: 0 })`. A numeric zero is a valid duration, so it no longer gets dropped as if the option was omitted.
+Fix `RcRef.make` to treat `idleTimeToLive: 0` like `Duration.zero` and `"0 millis"`. Release runs in a forked fiber and is not awaited by the scope releasing the last reference. Omitting `idleTimeToLive` still releases the resource within that scope and awaits completion.

--- a/.changeset/fix-rcref-idle-ttl-zero.md
+++ b/.changeset/fix-rcref-idle-ttl-zero.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Keep `RcRef.make({ idleTimeToLive: 0 })`. A numeric zero is a valid duration, so it no longer gets dropped as if the option was omitted.

--- a/packages/effect/src/RcRef.ts
+++ b/packages/effect/src/RcRef.ts
@@ -158,12 +158,16 @@ export const make: <A, E, R>(
   options: {
     readonly acquire: Effect.Effect<A, E, R>
     /**
-     * When the reference count reaches zero, the resource will be released
-     * after this duration.
+     * How long to keep an idle resource after its last reference is released.
      *
-     * For finite durations, including `0`, release runs in a forked fiber
-     * and is not awaited by the scope releasing the last reference. Omitting
-     * this option releases the resource within that scope and awaits completion.
+     * If the resource has not been invalidated, finite durations, including `0`,
+     * schedule release in a forked fiber that the scope releasing the last
+     * reference does not await. An infinite duration keeps the idle resource
+     * until invalidation or the RcRef's scope closes.
+     *
+     * If this option is omitted or the resource has been invalidated with
+     * `RcRef.invalidate`, the scope releasing the last reference releases the
+     * resource and awaits completion.
      */
     readonly idleTimeToLive?: Duration.Input | undefined
   }

--- a/packages/effect/src/RcRef.ts
+++ b/packages/effect/src/RcRef.ts
@@ -160,6 +160,10 @@ export const make: <A, E, R>(
     /**
      * When the reference count reaches zero, the resource will be released
      * after this duration.
+     *
+     * For finite durations, including `0`, release runs in a forked fiber
+     * and is not awaited by the scope releasing the last reference. Omitting
+     * this option releases the resource within that scope and awaits completion.
      */
     readonly idleTimeToLive?: Duration.Input | undefined
   }

--- a/packages/effect/src/internal/rcRef.ts
+++ b/packages/effect/src/internal/rcRef.ts
@@ -79,7 +79,9 @@ export const make = <A, E, R>(options: {
       options.acquire as Effect.Effect<A, E>,
       context,
       scope,
-      options.idleTimeToLive ? Duration.fromInputUnsafe(options.idleTimeToLive) : undefined
+      options.idleTimeToLive !== undefined
+        ? Duration.fromInputUnsafe(options.idleTimeToLive)
+        : undefined
     )
     return Effect.as(
       Scope.addFinalizerExit(scope, () => {

--- a/packages/effect/test/RcRef.test.ts
+++ b/packages/effect/test/RcRef.test.ts
@@ -287,22 +287,30 @@ describe("RcRef", () => {
       assert.strictEqual(released, 2)
     }))
 
-  it.effect("idleTimeToLive 0 schedules resource release", () =>
+  it.effect("idleTimeToLive 0 releases resources after a zero-duration sleep", () =>
     Effect.gen(function*() {
       const clock = yield* Clock.Clock
-      const sleeps: Array<Duration.Duration> = []
+      const sleeps: Array<number> = []
+      let released = 0
       const ref = yield* RcRef.make({
-        acquire: Effect.succeed("foo"),
+        acquire: Effect.acquireRelease(
+          Effect.succeed("foo"),
+          () =>
+            Effect.sync(() => {
+              released++
+            })
+        ),
         idleTimeToLive: 0
       }).pipe(Effect.provideService(Clock.Clock, {
         ...clock,
         sleep: (duration) => {
-          sleeps.push(duration)
+          sleeps.push(Duration.toMillis(duration))
           return clock.sleep(duration)
         }
       }))
 
       yield* Effect.scoped(RcRef.get(ref))
-      assert.deepStrictEqual(sleeps, [Duration.zero])
+      assert.deepStrictEqual(sleeps, [0])
+      assert.strictEqual(released, 1)
     }))
 })

--- a/packages/effect/test/RcRef.test.ts
+++ b/packages/effect/test/RcRef.test.ts
@@ -1,4 +1,5 @@
-import { assert, describe, it, vi } from "@effect/vitest"
+import { assert, describe, it } from "@effect/vitest"
+import * as Clock from "effect/Clock"
 import * as Deferred from "effect/Deferred"
 import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
@@ -286,14 +287,22 @@ describe("RcRef", () => {
       assert.strictEqual(released, 2)
     }))
 
-  it.effect("idleTimeToLive 0 is decoded instead of dropped", () =>
+  it.effect("idleTimeToLive 0 schedules resource release", () =>
     Effect.gen(function*() {
-      const spy = yield* Effect.sync(() => vi.spyOn(Duration, "fromInputUnsafe"))
-      yield* RcRef.make({
+      const clock = yield* Clock.Clock
+      const sleeps: Array<Duration.Duration> = []
+      const ref = yield* RcRef.make({
         acquire: Effect.succeed("foo"),
         idleTimeToLive: 0
-      })
-      assert.isTrue(spy.mock.calls.some((call) => Object.is(call[0], 0)))
-      spy.mockRestore()
+      }).pipe(Effect.provideService(Clock.Clock, {
+        ...clock,
+        sleep: (duration) => {
+          sleeps.push(duration)
+          return clock.sleep(duration)
+        }
+      }))
+
+      yield* Effect.scoped(RcRef.get(ref))
+      assert.deepStrictEqual(sleeps, [Duration.zero])
     }))
 })

--- a/packages/effect/test/RcRef.test.ts
+++ b/packages/effect/test/RcRef.test.ts
@@ -1,5 +1,6 @@
-import { assert, describe, it } from "@effect/vitest"
+import { assert, describe, it, vi } from "@effect/vitest"
 import * as Deferred from "effect/Deferred"
+import * as Duration from "effect/Duration"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
 import * as Fiber from "effect/Fiber"
@@ -283,5 +284,16 @@ describe("RcRef", () => {
 
       yield* TestClock.adjust("10 millis")
       assert.strictEqual(released, 2)
+    }))
+
+  it.effect("idleTimeToLive 0 is decoded instead of dropped", () =>
+    Effect.gen(function*() {
+      const spy = yield* Effect.sync(() => vi.spyOn(Duration, "fromInputUnsafe"))
+      yield* RcRef.make({
+        acquire: Effect.succeed("foo"),
+        idleTimeToLive: 0
+      })
+      assert.isTrue(spy.mock.calls.some((call) => Object.is(call[0], 0)))
+      spy.mockRestore()
     }))
 })


### PR DESCRIPTION
`RcRef.make({ idleTimeToLive: 0 })` now preserves numeric zero as a duration, matching `Duration.zero` and `"0 millis"` in RcRef.

When the last reference to a resource that has not been invalidated is released, a zero TTL runs the zero-duration sleep and resource release in a forked fiber. The scope releasing that reference does not await the release. If `idleTimeToLive` is omitted or the resource has been invalidated with `RcRef.invalidate`, that scope releases the resource and awaits completion.

The regression verifies both the zero-duration sleep and completed resource release. All 8 tests in `packages/effect/test/RcRef.test.ts` pass, and restoring the original truthiness check makes the regression fail.

Closes EFF-1358
