### PR TITLE
fix(http): fail active multipart file parts on upstream body failure

### DIFF
--- a/.changeset/fix-multipart-upstream-failure.md
+++ b/.changeset/fix-multipart-upstream-failure.md
@@ -1,0 +1,5 @@
+---
+"effect": patch
+---
+
+Fail active multipart file parts when the request body stream errors, instead of hanging until the consumer times out.

--- a/packages/effect/src/unstable/http/Multipart.ts
+++ b/packages/effect/src/unstable/http/Multipart.ts
@@ -281,6 +281,8 @@ export class MultipartError extends Data.TaggedError("MultipartError")<{
   }
 }
 
+const isMultipartError = (u: unknown): u is MultipartError => Predicate.hasProperty(u, MultipartErrorTypeId)
+
 /**
  * Schema type for persisted multipart files.
  *
@@ -469,6 +471,7 @@ export const makeChannel = <IE>(headers: Record<string, string>): Channel.Channe
     Effect.map(makeConfig(headers), (config) => {
       let partsBuffer: Array<Part> = []
       let exit = Option.none<Exit.Exit<never, IE | MultipartError | Cause.Done>>()
+      let upstreamFailure = Option.none<Cause.Cause<MultipartError>>()
       let ended = false
 
       const parser = MP.make({
@@ -480,9 +483,19 @@ export const makeChannel = <IE>(headers: Record<string, string>): Channel.Channe
           let chunks: Array<Uint8Array> = []
           let finished = false
           const pullChunks = Channel.fromPull(
-            Effect.succeed(Effect.suspend(function loop(): Pull.Pull<Arr.NonEmptyReadonlyArray<Uint8Array>> {
+            Effect.succeed(Effect.suspend(function loop(): Pull.Pull<
+              Arr.NonEmptyReadonlyArray<Uint8Array>,
+              MultipartError
+            > {
               if (!Arr.isReadonlyArrayNonEmpty(chunks)) {
-                return finished ? Cause.done() : Effect.flatMap(pump, loop)
+                if (finished) {
+                  return Cause.done()
+                }
+                // The parser never sees an upstream failure, so it cannot end
+                // this file. Fail the part instead of pumping a dead upstream.
+                return Option.isSome(upstreamFailure)
+                  ? Effect.failCause(upstreamFailure.value)
+                  : Effect.flatMap(pump, loop)
               }
               const chunk = chunks
               chunks = []
@@ -523,6 +536,12 @@ export const makeChannel = <IE>(headers: Record<string, string>): Channel.Channe
             }
           } else {
             exit = Option.some(Exit.failCause(cause)) as any
+            upstreamFailure = Option.some(
+              Cause.map(
+                cause,
+                (error) => isMultipartError(error) ? error : MultipartError.fromReason("InternalError", error)
+              )
+            )
           }
           return Effect.void
         })
@@ -614,17 +633,14 @@ class FileImpl extends PartBase implements File {
 
   constructor(
     info: MP.PartInfo,
-    channel: Channel.Channel<Arr.NonEmptyReadonlyArray<Uint8Array>>
+    channel: Channel.Channel<Arr.NonEmptyReadonlyArray<Uint8Array>, MultipartError>
   ) {
     super()
     this.key = info.name
     this.name = info.filename ?? info.name
     this.contentType = info.contentType
     this.content = Stream.fromChannel(channel)
-    this.contentEffect = channel.pipe(
-      Channel.mkUint8Array,
-      Effect.mapError((cause) => MultipartError.fromReason("InternalError", cause))
-    )
+    this.contentEffect = Channel.mkUint8Array(channel)
   }
 
   toJSON(): unknown {
@@ -644,7 +660,7 @@ const defaultWriteFile = (path: string, file: File) =>
     (fs) =>
       Effect.mapError(
         Stream.run(file.content, fs.sink(path)),
-        (cause) => MultipartError.fromReason("InternalError", cause)
+        (cause) => isMultipartError(cause) ? cause : MultipartError.fromReason("InternalError", cause)
       )
   )
 

--- a/packages/effect/test/unstable/http/Multipart.test.ts
+++ b/packages/effect/test/unstable/http/Multipart.test.ts
@@ -273,6 +273,104 @@ describe("Multipart", () => {
       strictEqual(error.reason._tag, "Parse")
     }))
 
+  it.effect("propagates an upstream failure to an active file part", () =>
+    Effect.gen(function*() {
+      const boundary = "----testboundary"
+      const encoder = new TextEncoder()
+      let fileParts = 0
+      let bytesRead = 0
+      const fileStart = `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="file"; filename="file.txt"\r\n` +
+        `Content-Type: text/plain\r\n\r\n` +
+        "a".repeat(1024)
+
+      const error = yield* Stream.make(encoder.encode(fileStart)).pipe(
+        Stream.concat(Stream.fail(Multipart.MultipartError.fromReason("InternalError", new Error("body-read-failed")))),
+        Stream.pipeThroughChannel(
+          Multipart.makeChannel({ "content-type": `multipart/form-data; boundary=${boundary}` })
+        ),
+        Stream.mapEffect((part) => {
+          if (part._tag !== "File") {
+            return Effect.void
+          }
+          fileParts++
+          return Stream.runForEach(part.content, (chunk) =>
+            Effect.sync(() => {
+              bytesRead += chunk.length
+            }))
+        }),
+        Stream.runDrain,
+        Effect.flip
+      )
+
+      strictEqual(fileParts, 1)
+      // bytes received before the failure are delivered, then the part fails
+      strictEqual(bytesRead > 0, true)
+      strictEqual(error._tag, "MultipartError")
+      strictEqual(error.reason._tag, "InternalError")
+    }))
+
+  it.effect("propagates an upstream failure when the file part is never consumed", () =>
+    Effect.gen(function*() {
+      const boundary = "----testboundary"
+      const encoder = new TextEncoder()
+      let fileParts = 0
+      const fileStart = `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="file"; filename="file.txt"\r\n` +
+        `Content-Type: text/plain\r\n\r\n` +
+        "a"
+
+      const error = yield* Stream.make(encoder.encode(fileStart)).pipe(
+        Stream.concat(Stream.fail(Multipart.MultipartError.fromReason("InternalError", new Error("body-read-failed")))),
+        Stream.pipeThroughChannel(
+          Multipart.makeChannel({ "content-type": `multipart/form-data; boundary=${boundary}` })
+        ),
+        Stream.mapEffect((part) => {
+          if (part._tag === "File") {
+            fileParts++
+          }
+          return Effect.void
+        }),
+        Stream.runDrain,
+        Effect.flip
+      )
+
+      strictEqual(fileParts, 1)
+      strictEqual(error._tag, "MultipartError")
+      strictEqual(error.reason._tag, "InternalError")
+    }))
+
+  it.effect("propagates an upstream failure to an active file part collected with contentEffect", () =>
+    Effect.gen(function*() {
+      const boundary = "----testboundary"
+      const encoder = new TextEncoder()
+      let fileParts = 0
+      const fileStart = `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="file"; filename="file.txt"\r\n` +
+        `Content-Type: text/plain\r\n\r\n` +
+        "a"
+
+      const error = yield* Stream.make(encoder.encode(fileStart)).pipe(
+        Stream.concat(Stream.fail(Multipart.MultipartError.fromReason("InternalError", new Error("body-read-failed")))),
+        Stream.pipeThroughChannel(
+          Multipart.makeChannel({ "content-type": `multipart/form-data; boundary=${boundary}` })
+        ),
+        Stream.mapEffect((part) => {
+          if (part._tag !== "File") {
+            return Effect.void
+          }
+          fileParts++
+          return part.contentEffect
+        }),
+        Stream.runDrain,
+        Effect.flip
+      )
+
+      strictEqual(fileParts, 1)
+      strictEqual(error._tag, "MultipartError")
+      strictEqual(error.reason._tag, "InternalError")
+    }))
+
   it.each<{
     description: string
     options: {


### PR DESCRIPTION
Fixes #8203

## Summary

- fail an active multipart file part when the request body stream errors, instead of pumping a dead upstream forever
- normalize the upstream cause to a `MultipartError` so `File.content` and `File.contentEffect` keep their declared error type
- add regression tests for a failing body during an active file, for `contentEffect`, and for a file part that is never consumed
- add a patch changeset

## Root cause

In `Multipart.makeChannel`, `pump` records an upstream failure in `exit` and the outer part loop checks it, but the per-file pull loop created in `onFile` only checked its own `finished` flag:

```ts
return finished ? Cause.done() : Effect.flatMap(pump, loop)
```

The parser is never told about an upstream failure (`parser.end()` only runs on `Done`), so it cannot send the active file callback its terminating `null`. `finished` therefore stays `false` and a consumer draining `part.content` calls `pump` on an already-failed upstream forever. The loop never yields, so the failure surfaces only when an outer watchdog fires, and in the tests here even `Effect.timeout` inside the same fiber never gets a chance to run.

This is a different trigger from #7155 / #7156. Those covered parser limit and truncated-input failures, which the parser can observe and which it now terminates by sending `null` to the active file. An upstream stream failure is invisible to the parser, so it has to be handled in the wrapper.

## Change

`makeChannel` keeps the upstream cause in a new `upstreamFailure` slot next to the existing `exit`, mapped so a cause that is already a `MultipartError` passes through and anything else becomes `InternalError`. The file pull loop drains any buffered chunks first, then ends on `finished`, and otherwise fails with that cause rather than pumping again.

Because the file channel can now fail, its error type widens from `never` to `MultipartError`. This is internal only: the public `File.content` and `File.contentEffect` were already typed as failing with `MultipartError`. `FileImpl.contentEffect` therefore no longer needs to wrap the channel error, and `defaultWriteFile` now passes an existing `MultipartError` through instead of re-wrapping it as `InternalError`.

A file that completed before the failure still ends cleanly, so the parser-limit behavior from #7156 is unchanged.

## Validation

- `pnpm test --run packages/effect/test/unstable/http/Multipart.test.ts` (19 tests)
- the two new consuming tests hang and time out on `main`, and pass with the change
- `pnpm test --run packages/effect/test/unstable/http/HttpServerRequest.test.ts packages/effect/test/unstable/http/HttpServer.test.ts packages/effect/test/unstable/http/HttpPlatform.test.ts`
- `pnpm test --run packages/platform/node/test/MultipartParser.test.ts packages/platform/node/test/HttpApi.test.ts` (128 tests)
- `pnpm lint`, `pnpm check`

The issue reproduces through `@effect/platform-bun`, but the hang is in the shared `effect/unstable/http/Multipart` channel that `BunMultipart.stream` pipes through, so the regression tests live with the core module. Bun was not available locally to run the reporter's script directly.
