### PR TITLE
fix(openapi-generator): type binary multipart fields as File | Blob

### DIFF
--- a/.changeset/multipart-binary-client-file-type.md
+++ b/.changeset/multipart-binary-client-file-type.md
@@ -1,0 +1,7 @@
+---
+"@effect/openapi-generator": patch
+---
+
+Generated HTTP clients now type `multipart/form-data` fields that use `format: binary` as `globalThis.File | globalThis.Blob`.
+
+A binary field was previously emitted as `string`, so passing a `File` (the value accepted by `HttpClientRequest.bodyFormDataRecord`) failed to type-check even though it worked at runtime. `httpapi` output is unchanged.

--- a/packages/tools/openapi-generator/src/JsonSchemaGenerator.ts
+++ b/packages/tools/openapi-generator/src/JsonSchemaGenerator.ts
@@ -35,8 +35,19 @@ interface MultipartSchemaRefs {
   readonly files: string
 }
 
-interface GenerateHttpApiOptions extends GenerateOptions {
+interface GenerateHttpApiOptions extends GenerateOptions, RenderSchemaTypeAndRuntimeOptions {
   readonly multipartSchemaRefs?: MultipartSchemaRefs | undefined
+}
+
+interface RenderSchemaTypeAndRuntimeOptions {
+  readonly multipartSchemaRefs?: MultipartSchemaRefs | undefined
+  /**
+   * Synthetic `$ref` name used for binary multipart fields in generated
+   * clients. Clients build request bodies from `File` / `Blob` values, so the
+   * field is rendered as `globalThis.File | globalThis.Blob` instead of a
+   * server-side persisted file.
+   */
+  readonly clientMultipartFileRef?: string | undefined
 }
 
 /**
@@ -70,7 +81,7 @@ function makeWithRepresentation() {
     source: Source,
     components: JsonSchema.Definitions,
     typeOnly: boolean,
-    options?: GenerateOptions
+    options?: GenerateHttpApiOptions
   ) {
     const generated = makeCodeDocument(source, components, options)
     if (generated === undefined) {
@@ -81,7 +92,7 @@ function makeWithRepresentation() {
     const recursiveReferences = Object.entries(generated.codeDocument.references.recursives)
 
     const nonRecursives = nonRecursiveReferences.map(({ $ref, code }) =>
-      renderSchemaTypeAndRuntime($ref, code, typeOnly)
+      renderSchemaTypeAndRuntime($ref, code, typeOnly, options)
     )
 
     const recursiveDeclarations: Array<string> = []
@@ -89,7 +100,7 @@ function makeWithRepresentation() {
 
     if (typeOnly) {
       for (const [$ref, code] of recursiveReferences) {
-        recursives.push(renderSchemaTypeAndRuntime($ref, code, true))
+        recursives.push(renderSchemaTypeAndRuntime($ref, code, true, options))
       }
     } else {
       const recursivelyForwardReferenced = collectForwardReferencedRecursives(
@@ -113,12 +124,12 @@ function makeWithRepresentation() {
           continue
         }
 
-        recursives.push(renderSchemaTypeAndRuntime($ref, code, false))
+        recursives.push(renderSchemaTypeAndRuntime($ref, code, false, options))
       }
     }
 
     const codes = generated.codeDocument.codes.map((code, i) =>
-      renderSchemaTypeAndRuntime(generated.nameMap[i], code, typeOnly)
+      renderSchemaTypeAndRuntime(generated.nameMap[i], code, typeOnly, options)
     )
 
     return renderImportArtifacts(generated.codeDocument, !typeOnly) +
@@ -142,7 +153,7 @@ function makeWithRepresentation() {
     const recursiveReferences = Object.entries(generated.codeDocument.references.recursives)
 
     const nonRecursives = nonRecursiveReferences.map(({ $ref, code }) =>
-      renderSchemaTypeAndRuntime($ref, code, false, options?.multipartSchemaRefs)
+      renderSchemaTypeAndRuntime($ref, code, false, options)
     )
 
     const recursivelyForwardReferenced = collectForwardReferencedRecursives(nonRecursiveReferences, recursiveReferences)
@@ -166,11 +177,11 @@ function makeWithRepresentation() {
         continue
       }
 
-      recursives.push(renderSchemaTypeAndRuntime($ref, code, false, options?.multipartSchemaRefs))
+      recursives.push(renderSchemaTypeAndRuntime($ref, code, false, options))
     }
 
     const codes = generated.codeDocument.codes.map((code, i) =>
-      renderSchemaTypeAndRuntime(generated.nameMap[i], code, false, options?.multipartSchemaRefs)
+      renderSchemaTypeAndRuntime(generated.nameMap[i], code, false, options)
     )
 
     return renderImportArtifacts(generated.codeDocument, true) +
@@ -278,8 +289,9 @@ function renderSchemaTypeAndRuntime(
   $ref: string,
   code: SchemaRepresentation.Code,
   typeOnly: boolean,
-  multipartSchemaRefs?: MultipartSchemaRefs
+  options?: RenderSchemaTypeAndRuntimeOptions
 ) {
+  const multipartSchemaRefs = options?.multipartSchemaRefs
   if (!typeOnly && multipartSchemaRefs !== undefined) {
     if ($ref === multipartSchemaRefs.singleFile) {
       return [
@@ -293,6 +305,20 @@ function renderSchemaTypeAndRuntime(
         `export const ${$ref} = Multipart.FilesSchema`
       ].join("\n")
     }
+  }
+  if (options?.clientMultipartFileRef !== undefined && $ref === options.clientMultipartFileRef) {
+    const type = `export type ${$ref} = globalThis.File | globalThis.Blob`
+    if (typeOnly) {
+      return type
+    }
+    return [
+      type,
+      `export const ${$ref} = Schema.declare(` +
+      `(value: unknown): value is globalThis.File | globalThis.Blob => ` +
+      `(typeof globalThis.File !== "undefined" && value instanceof globalThis.File) || ` +
+      `(typeof globalThis.Blob !== "undefined" && value instanceof globalThis.Blob), ` +
+      `{ expected: "File | Blob" })`
+    ].join("\n")
   }
 
   const strings = [`export type ${$ref} = ${code.Type}`]

--- a/packages/tools/openapi-generator/src/OpenApiGenerator.ts
+++ b/packages/tools/openapi-generator/src/OpenApiGenerator.ts
@@ -149,8 +149,19 @@ export const make = Effect.gen(function*() {
       const multipartSchemaRefs = options.format === "httpapi"
         ? makeHttpApiMultipartSchemaRefs(spec.components?.schemas ?? {})
         : undefined
+      const clientMultipartFileRef = options.format === "httpapi"
+        ? undefined
+        : makeClientMultipartFileRef(spec.components?.schemas ?? {})
 
-      const parsed = parseOpenApi(spec, generator, resolveRef, options.format, emitWarning, multipartSchemaRefs)
+      const parsed = parseOpenApi(
+        spec,
+        generator,
+        resolveRef,
+        options.format,
+        emitWarning,
+        multipartSchemaRefs,
+        clientMultipartFileRef
+      )
 
       // TODO: make a CLI option ?
       const importName = "Schema"
@@ -166,10 +177,11 @@ export const make = Effect.gen(function*() {
         )
         : generator.generate(
           source,
-          spec.components?.schemas ?? {},
+          withClientMultipartSchemas(spec.components?.schemas ?? {}, clientMultipartFileRef),
           options.format === "httpclient-type-only",
           {
-            onEnter: options.onEnter
+            onEnter: options.onEnter,
+            clientMultipartFileRef
           }
         )
 
@@ -215,7 +227,8 @@ const parseOpenApi = (
   resolveRef: (ref: string) => unknown,
   format: OpenApiGeneratorFormat,
   emitWarning: WarningEmitter,
-  multipartSchemaRefs: HttpApiMultipartSchemaRefs | undefined
+  multipartSchemaRefs: HttpApiMultipartSchemaRefs | undefined,
+  clientMultipartFileRef: string | undefined
 ): ParsedOperation.ParsedOpenApi => {
   const operations: Array<ParsedOperation.ParsedOperation> = []
   const reservedSchemaNames = new Set<string>(Object.keys(spec.components?.schemas ?? {}))
@@ -420,7 +433,13 @@ const parseOpenApi = (
         if (Predicate.isNotUndefined(content["multipart/form-data"]?.schema)) {
           op.payload = addSchema(
             `${schemaId}RequestFormData`,
-            transformMultipartSchema(content["multipart/form-data"].schema, multipartSchemaRefs, resolveRef),
+            transformMultipartSchemaForFormat(
+              content["multipart/form-data"].schema,
+              format,
+              multipartSchemaRefs,
+              clientMultipartFileRef,
+              resolveRef
+            ),
             op
           )
           op.payloadFormData = true
@@ -450,7 +469,13 @@ const parseOpenApi = (
             let schemaName = requestSchemaNames.get(contentType)
             if (schemaName === undefined) {
               const schema = encoding === "multipart"
-                ? transformMultipartSchema(mediaType.schema as JsonSchema.JsonSchema, multipartSchemaRefs, resolveRef)
+                ? transformMultipartSchemaForFormat(
+                  mediaType.schema as JsonSchema.JsonSchema,
+                  format,
+                  multipartSchemaRefs,
+                  clientMultipartFileRef,
+                  resolveRef
+                )
                 : mediaType.schema as JsonSchema.JsonSchema
               schemaName = addSchema(
                 `${schemaId}Request${mediaTypeToSuffix(contentType)}`,
@@ -849,6 +874,49 @@ const makeHttpApiMultipartSchemaRefs = (definitions: JsonSchema.Definitions): Ht
 
 const toDefinitionRef = (name: string): string => `#/$defs/${name.replaceAll("~", "~0").replaceAll("/", "~1")}`
 
+/**
+ * Synthetic `$ref` used by generated clients for binary multipart fields.
+ *
+ * Clients send request bodies built from `File` / `Blob` values, so these
+ * fields must not reuse the server-side persisted file schema.
+ */
+const makeClientMultipartFileRef = (definitions: JsonSchema.Definitions): string => {
+  const names = new Set(Object.keys(definitions))
+  let candidate = "__ClientMultipartFile"
+  let index = 2
+  while (names.has(candidate)) {
+    candidate = `__ClientMultipartFile${index}`
+    index += 1
+  }
+  return candidate
+}
+
+type MultipartSchemaTransform =
+  | {
+    readonly mode: "httpApi"
+    readonly refs: HttpApiMultipartSchemaRefs
+  }
+  | {
+    readonly mode: "client"
+    readonly fileRef: string
+  }
+
+const withClientMultipartSchemas = (
+  definitions: JsonSchema.Definitions,
+  clientMultipartFileRef: string | undefined
+): JsonSchema.Definitions => {
+  if (clientMultipartFileRef === undefined) {
+    return definitions
+  }
+  return {
+    ...definitions,
+    [clientMultipartFileRef]: {
+      type: "string",
+      format: "binary"
+    }
+  }
+}
+
 const withHttpApiMultipartSchemas = (
   definitions: JsonSchema.Definitions,
   multipartSchemaRefs: HttpApiMultipartSchemaRefs | undefined,
@@ -857,8 +925,9 @@ const withHttpApiMultipartSchemas = (
   if (multipartSchemaRefs === undefined) {
     return definitions
   }
+  const transform: MultipartSchemaTransform = { mode: "httpApi", refs: multipartSchemaRefs }
   return {
-    ...Rec.map(definitions, (schema) => transformMultipartSchema(schema, multipartSchemaRefs, resolveRef)),
+    ...Rec.map(definitions, (schema) => transformMultipartSchema(schema, transform, resolveRef)),
     [multipartSchemaRefs.singleFile]: {
       type: "string",
       format: "binary"
@@ -872,17 +941,36 @@ const withHttpApiMultipartSchemas = (
   }
 }
 
-const transformMultipartSchema = (
+const transformMultipartSchemaForFormat = (
   schema: JsonSchema.JsonSchema,
+  format: OpenApiGeneratorFormat,
   multipartSchemaRefs: HttpApiMultipartSchemaRefs | undefined,
+  clientMultipartFileRef: string | undefined,
   resolveRef: (ref: string) => unknown
 ): JsonSchema.JsonSchema => {
-  if (multipartSchemaRefs === undefined) {
+  if (format === "httpapi") {
+    return multipartSchemaRefs === undefined
+      ? schema
+      : transformMultipartSchema(schema, { mode: "httpApi", refs: multipartSchemaRefs }, resolveRef)
+  }
+  return clientMultipartFileRef === undefined
+    ? schema
+    : transformMultipartSchema(schema, { mode: "client", fileRef: clientMultipartFileRef }, resolveRef)
+}
+
+const transformMultipartSchema = (
+  schema: JsonSchema.JsonSchema,
+  input: MultipartSchemaTransform | undefined,
+  resolveRef: (ref: string) => unknown
+): JsonSchema.JsonSchema => {
+  if (input === undefined) {
     return schema
   }
 
-  const singleFileRef = toDefinitionRef(multipartSchemaRefs.singleFile)
-  const filesRef = toDefinitionRef(multipartSchemaRefs.files)
+  const singleFileRef = input.mode === "httpApi"
+    ? toDefinitionRef(input.refs.singleFile)
+    : `#/$defs/${input.fileRef}`
+  const filesRef = input.mode === "httpApi" ? toDefinitionRef(input.refs.files) : undefined
   const cache = new Map<string, unknown>()
   const stack = new Set<string>()
 
@@ -922,7 +1010,7 @@ const transformMultipartSchema = (
     }
 
     if (isMultipartBinaryFiles(out, singleFileRef)) {
-      return { $ref: filesRef }
+      return filesRef === undefined ? out : { $ref: filesRef }
     }
 
     return out

--- a/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
+++ b/packages/tools/openapi-generator/test/OpenApiGenerator.test.ts
@@ -92,6 +92,11 @@ function assertGeneratedClientsCompile(
   options: {
     readonly exactOptionalPropertyTypes?: boolean | undefined
     readonly formats?: ReadonlyArray<"httpclient" | "httpclient-type-only"> | undefined
+    /**
+     * Extra source checked next to the generated client for the matching
+     * format. Use it to assert that call sites accept real payload values.
+     */
+    readonly usages?: Partial<Record<"httpclient" | "httpclient-type-only", string>> | undefined
   } = {}
 ) {
   const generate = (
@@ -119,6 +124,13 @@ function assertGeneratedClientsCompile(
         const path = join(directory, `Client${index}.ts`)
         writeFileSync(path, client)
         return path
+      })
+      formats.forEach((format, index) => {
+        const usage = options.usages?.[format]
+        if (usage === undefined) return
+        const path = join(directory, `Usage${index}.ts`)
+        writeFileSync(path, usage.replaceAll("__CLIENT__", `./Client${index}.ts`))
+        files.push(path)
       })
       const configPath = join(directory, "tsconfig.json")
       writeFileSync(
@@ -3015,6 +3027,55 @@ export const __HttpApiMultipartFiles = Multipart.FilesSchema`,
         {
           exactOptionalPropertyTypes: false,
           formats: ["httpclient"]
+        }
+      ))
+
+    it.effect("types multipart binary fields as File | Blob for generated clients", () =>
+      assertGeneratedClientsCompile(
+        {
+          openapi: "3.1.0",
+          info: { title: "Upload API", version: "1.0.0" },
+          paths: {
+            "/upload": {
+              post: {
+                operationId: "upload",
+                parameters: [],
+                requestBody: {
+                  required: true,
+                  content: {
+                    "multipart/form-data": {
+                      schema: {
+                        type: "object",
+                        properties: { file: { type: "string", format: "binary" } },
+                        required: ["file"],
+                        additionalProperties: false
+                      }
+                    }
+                  }
+                },
+                responses: { "204": { description: "Uploaded" } },
+                tags: ["Upload"],
+                security: []
+              }
+            }
+          },
+          components: { schemas: {}, securitySchemes: {} },
+          security: [],
+          tags: [{ name: "Upload" }]
+        },
+        {
+          usages: {
+            httpclient: `import type { UploadRequestFormData } from "__CLIENT__"
+
+// File and Blob must both be assignable (HttpBody.FormDataCoercible).
+export const withFile: UploadRequestFormData = { file: new File(["hello"], "hello.txt") }
+export const withBlob: UploadRequestFormData = { file: new Blob(["hello"]) }
+`,
+            "httpclient-type-only": `import type { UploadRequestFormData } from "__CLIENT__"
+
+export const withFile: UploadRequestFormData = { file: new File(["hello"], "hello.txt") }
+`
+          }
         }
       ))
   })


### PR DESCRIPTION
## Summary

Generated HTTP clients emitted `string` for `multipart/form-data` fields that use
`format: binary`. `HttpClientRequest.bodyFormDataRecord` accepts `File` / `Blob`
at runtime, so a `File` payload was rejected by the generated type
(`TS2322: Type 'File' is not assignable to type 'string'`) even though it worked
when sent.

Client formats now replace those fields with a generated
`globalThis.File | globalThis.Blob` type by reusing the existing multipart schema
substitution. `--format httpapi` is unchanged.

Closes #8204
Closes EFF-1365

## Before / after (`--format httpclient`)

```ts
// before
export type UploadRequestFormData = { readonly "file": string }

// after
export type UploadRequestFormData = { readonly "file": __ClientMultipartFile }
```

## Test plan

- [x] `vitest --run packages/tools/openapi-generator/test/OpenApiGenerator.test.ts` (36 passed)
- [x] New regression test `types multipart binary fields as File | Blob for generated clients`
      compiles usage assigning `File` and `Blob` to the payload and rejecting strings for both
      `httpclient` and `httpclient-type-only`
- [x] `pnpm check`
- [x] `pnpm lint-fix`
