### PR TITLE
feat(http): expose the original Web Response on HttpClientResponse

### DIFF
--- a/.changeset/httpclient-response-to-web.md
+++ b/.changeset/httpclient-response-to-web.md
@@ -1,0 +1,7 @@
+---
+"effect": patch
+---
+
+Add `HttpClientResponse.toWeb`, which returns the original Web `Response` backing a client response when the client exposes one.
+
+The returned response keeps runtime-specific body capabilities that a stream rebuilt in JavaScript cannot carry. On workerd, `HttpClientResponse.toWeb(response)?.body` reports a known length to `R2Bucket.put`, while `Stream.toReadableStreamEffect(response.stream)` produces a rebuilt stream that does not.

--- a/packages/effect/src/unstable/http/HttpClient.ts
+++ b/packages/effect/src/unstable/http/HttpClient.ts
@@ -1721,6 +1721,10 @@ class InterruptibleResponse implements HttpClientResponse.HttpClientResponse, Pi
     return this.original.request
   }
 
+  get source() {
+    return this.original.source
+  }
+
   get url() {
     return this.original.url
   }

--- a/packages/effect/src/unstable/http/HttpClientResponse.ts
+++ b/packages/effect/src/unstable/http/HttpClientResponse.ts
@@ -67,6 +67,17 @@ export interface HttpClientResponse extends HttpIncomingMessage.HttpIncomingMess
   readonly [TypeId]: typeof TypeId
   readonly request: HttpClientRequest.HttpClientRequest
   /**
+   * The platform response this value was built from, when the client exposes one.
+   *
+   * **Details**
+   *
+   * `FetchHttpClient` exposes the original Web `Response`. Keeping that object
+   * matters on runtimes that attach capabilities to it: on workerd, only a
+   * native response body reports a known length to `R2Bucket.put`, and any
+   * stream rebuilt in JavaScript loses it. Use `toWeb` to narrow this value.
+   */
+  readonly source?: object | undefined
+  /**
    * The resolved URL, including query parameters and excluding the hash.
    * Uses the final URL when redirects are followed. Empty if unknown.
    */
@@ -75,6 +86,30 @@ export interface HttpClientResponse extends HttpIncomingMessage.HttpIncomingMess
   readonly cookies: Cookies.Cookies
   readonly formData: Effect.Effect<FormData, Error.HttpClientError>
 }
+
+/**
+ * Returns the original Web `Response` backing a client response, when available.
+ *
+ * **When to use**
+ *
+ * Use when you need the native response object instead of the Effect body
+ * accessors, for example to hand its body to a runtime API that inspects it.
+ *
+ * **Details**
+ *
+ * The returned `Response` is the same object the client received, so its body
+ * keeps runtime-specific capabilities that a rebuilt stream cannot carry. On
+ * workerd, `Response.body` reports a known length to `R2Bucket.put` while
+ * `Stream.toReadableStream` output does not. Returns `undefined` for clients
+ * that do not expose a Web `Response`.
+ *
+ * @category converting
+ * @since 4.0.0
+ */
+export const toWeb = (self: HttpClientResponse): globalThis.Response | undefined =>
+  typeof globalThis.Response !== "undefined" && self.source instanceof globalThis.Response
+    ? self.source
+    : undefined
 
 /**
  * Wraps a Web `Response` and its original `HttpClientRequest` as an `HttpClientResponse`.
@@ -257,7 +292,7 @@ class WebHttpClientResponse extends Inspectable.Class implements HttpClientRespo
   readonly [TypeId]: typeof TypeId
 
   readonly request: HttpClientRequest.HttpClientRequest
-  private readonly source: globalThis.Response
+  readonly source: globalThis.Response
 
   constructor(
     request: HttpClientRequest.HttpClientRequest,

--- a/packages/effect/test/unstable/http/HttpClientResponse.test.ts
+++ b/packages/effect/test/unstable/http/HttpClientResponse.test.ts
@@ -1,0 +1,36 @@
+import { assert, describe, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+
+describe("HttpClientResponse", () => {
+  describe("toWeb", () => {
+    it.effect("returns the original Web Response instead of rebuilding it", () =>
+      Effect.sync(() => {
+        const source = new Response(new Uint8Array([1, 2, 3]))
+        const response = HttpClientResponse.fromWeb(HttpClientRequest.get("https://example.com/"), source)
+
+        assert.strictEqual(HttpClientResponse.toWeb(response), source)
+        // The body must be the native one, not a stream rebuilt in JavaScript,
+        // so runtime-specific capabilities (e.g. workerd's known length) survive.
+        assert.strictEqual(HttpClientResponse.toWeb(response)?.body, source.body)
+      }))
+
+    it.effect("returns the original Web Response through HttpClient.execute", () =>
+      Effect.gen(function*() {
+        const source = new Response(new Uint8Array([1, 2, 3]))
+        const client = HttpClient.make((request) => Effect.succeed(HttpClientResponse.fromWeb(request, source)))
+
+        const response = yield* HttpClient.execute(HttpClientRequest.get("https://example.com/")).pipe(
+          Effect.provideService(HttpClient.HttpClient, client)
+        )
+
+        assert.strictEqual(HttpClientResponse.toWeb(response), source)
+      }))
+
+    it.effect("returns undefined when no Web Response backs the response", () =>
+      Effect.sync(() => {
+        const response = { source: {} } as unknown as HttpClientResponse.HttpClientResponse
+        assert.strictEqual(HttpClientResponse.toWeb(response), undefined)
+      }))
+  })
+})

--- a/packages/effect/typetest/unstable/http/HttpClientResponse.tst.ts
+++ b/packages/effect/typetest/unstable/http/HttpClientResponse.tst.ts
@@ -1,0 +1,18 @@
+import { HttpClientResponse } from "effect/unstable/http"
+import { describe, expect, it } from "tstyche"
+
+declare const response: HttpClientResponse.HttpClientResponse
+
+describe("HttpClientResponse", () => {
+  describe("source", () => {
+    it("should be an optional platform object", () => {
+      expect(response.source).type.toBe<object | undefined>()
+    })
+  })
+
+  describe("toWeb", () => {
+    it("should return the original Web Response when available", () => {
+      expect(HttpClientResponse.toWeb(response)).type.toBe<globalThis.Response | undefined>()
+    })
+  })
+})


### PR DESCRIPTION
## What was wrong

`HttpClientResponse` already holds the original Web `Response`, but the field was `private`, so nobody could get to it. The only public body API was the Effect `Stream`.

That bites on workerd. R2 refuses a stream unless it knows the length up front:

```text
Provided readable stream must have a known length (request/response body or readable half of FixedLengthStream)
```

The original response body knows its length. `Stream.toReadableStreamEffect(response.stream)` builds a brand new stream and throws that knowledge away. So this fails:

```ts
const body = yield* Stream.toReadableStreamEffect(response.stream)
yield* Effect.tryPromise(() => env.BACKUP.put(key, body))
```

## What this PR does

Adds `HttpClientResponse.toWeb` and exposes `source`, so you can hand R2 the original body:

```ts
const source = HttpClientResponse.toWeb(response)
if (source?.body) yield* Effect.tryPromise(() => env.BACKUP.put(key, source.body))
```

`HttpClientRequest`, `HttpServerRequest` and `HttpServerResponse` already had `toWeb`. This just fills the gap.

## Why not fix the stream conversion instead

Because it can't be fixed. The length is a marker on native workerd streams, and any `new ReadableStream({...})` drops it. A `Content-Length` header does not bring it back. On top of that, `HttpClient.execute` wraps the body in `Stream.ensuring(..., controller.abort())` to abort the request on interruption, and that finalizer has to keep running — we can't just pass the original stream through.

Same bytes, put into R2 in workerd:

| what you put in R2 | result |
| --- | --- |
| `new Response(bytes).body` | accepted |
| the original response body | accepted |
| `body.tee()[0]` | accepted |
| `new ReadableStream({ start })` | rejected |
| `new Response(stream, { "content-length": "3" }).body` | rejected |
| `toReadableStreamEffect(response.stream)` | rejected |

## Tests

I ran the whole repo suite from the repo root, the same way CI does (`pnpm test --run --max-concurrency=10`): **11848 passed**.

The only failures are environment problems that already fail on `main`:

- `platform-node-shared > NodeChildProcessSpawner`: the process-group kill tests also fail on `main` on this machine (started from a clean checkout of `main`)
- `effect > cluster/ClusterWorkflowEngine`: one flaky timeout under full-suite parallelism — it passes when run on its own, and 3 out of 3 on repeat

Plus:

- new `HttpClientResponse.test.ts` checks `toWeb` returns the very same `Response`, also through `HttpClient.execute`
- `pnpm check`, `test-types`, `oxlint`, `dprint check` → pass
- verified in workerd: `toWeb(response).body` accepted by R2, `toReadableStreamEffect(response.stream)` rejected
- `pnpm jsdocs --check` fails on `unstable/ai/McpSchema.ts` both before and after this change
