### PR TITLE
fix(sql-clickhouse): use ping for connection validation

### DIFF
--- a/.changeset/clickhouse-ping-check.md
+++ b/.changeset/clickhouse-ping-check.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-clickhouse": patch
+---
+
+Use ClickHouse's `ping()` endpoint for connection validation and map failed health checks to `SqlError` values.

--- a/packages/sql/clickhouse/src/ClickhouseClient.ts
+++ b/packages/sql/clickhouse/src/ClickhouseClient.ts
@@ -3,7 +3,7 @@
  *
  * This module provides both the ClickHouse-specific {@link ClickhouseClient}
  * service and the generic {@link Client.SqlClient} service. `make` creates a
- * scoped client, checks the connection with `SELECT 1`, maps ClickHouse errors
+ * scoped client, checks the connection with `ping()`, maps ClickHouse errors
  * to `SqlError`, and aborts in-flight queries when interrupted. The
  * ClickHouse-specific service adds typed parameters, command execution, insert
  * queries, query id and settings helpers, a statement compiler, and direct or
@@ -159,7 +159,7 @@ export interface ClickhouseClientConfig extends Clickhouse.ClickHouseClientConfi
 }
 
 /**
- * Creates a scoped `ClickhouseClient`, verifies connectivity with `SELECT 1`,
+ * Creates a scoped `ClickhouseClient`, verifies connectivity with `ping()`,
  * closes the underlying client when the scope ends, maps ClickHouse failures
  * to `SqlError`, and aborts plus kills in-flight queries when interrupted.
  *
@@ -181,7 +181,13 @@ export const make = (
     )
 
     yield* Effect.tryPromise({
-      try: () => client.exec({ query: "SELECT 1" }),
+      try: async () => {
+        const result = await client.ping()
+        if (!result.success) {
+          throw result.error
+        }
+        return result
+      },
       catch: (cause) =>
         new SqlError({ reason: classifyError(cause, "ClickhouseClient: Failed to connect", "connect", "connection") })
     }).pipe(

--- a/packages/sql/clickhouse/test/Client.test.ts
+++ b/packages/sql/clickhouse/test/Client.test.ts
@@ -12,7 +12,7 @@ const commandCalls: Array<Record<string, unknown>> = []
 
 vi.mock("@clickhouse/client", () => ({
   createClient: () => ({
-    exec: () => connectImmediately ? Promise.resolve({}) : new Promise(() => {}),
+    ping: () => connectImmediately ? Promise.resolve({ success: true }) : new Promise(() => {}),
     query: () => new Promise(() => {}),
     insert: () => new Promise(() => {}),
     command: (options: Record<string, unknown>) => {

--- a/packages/sql/clickhouse/test/SqlErrorClassification.test.ts
+++ b/packages/sql/clickhouse/test/SqlErrorClassification.test.ts
@@ -16,7 +16,10 @@ const state: {
 
 vi.mock("@clickhouse/client", () => ({
   createClient: () => ({
-    exec: () => state.connectCause ? Promise.reject(state.connectCause) : Promise.resolve({}),
+    ping: () =>
+      state.connectCause
+        ? Promise.resolve({ success: false, error: state.connectCause })
+        : Promise.resolve({ success: true }),
     close: () => Promise.resolve(),
     query: () =>
       state.queryCause


### PR DESCRIPTION
## Summary

Use `client.ping()` for ClickHouse connection validation.

`@clickhouse/client` returns ping failures inside `{ success: false, error }` instead of rejecting the Promise. This change explicitly throws the embedded error so the existing `SqlError` mapping handles connection failures correctly.

It also avoids using `exec("SELECT 1")` for the health check, which can leave a response stream active during scoped client shutdown and produce misleading socket cleanup warnings. 

## Reviewer guide

- Runtime connection validation — [ClickhouseClient.ts:L183-L192](https://github.com/Effect-TS/effect/blob/17f731e7e56a0a99a3053a18f4b255cfaa63e3b5/packages/sql/clickhouse/src/ClickhouseClient.ts#L183-L192) — Verify that successful pings allow layer initialization and failed discriminated results are converted into the existing `SqlError` path.

## Testing

- `pnpm lint-fix`
- `pnpm test --run packages/sql/clickhouse/test/Client.test.ts packages/sql/clickhouse/test/SqlErrorClassification.test.ts` (7 tests passed)
- `pnpm check`
- The requested `bun run index-effect.ts` probe was not run because `index-effect.ts` is not present in this checkout.

## Risks

Low. The change uses the ClickHouse client’s documented health-check API and preserves the existing timeout and error-classification behavior.

## Release notes

Included a patch changeset for `@effect/sql-clickhouse`.

Linear/GitHub issue: N/A
