### PR TITLE
fix(sql-clickhouse): use ClickHouse compiler dialect

### DIFF
--- a/.changeset/clickhouse-compiler-dialect.md
+++ b/.changeset/clickhouse-compiler-dialect.md
@@ -1,0 +1,5 @@
+---
+"@effect/sql-clickhouse": patch
+---
+
+Mark the ClickHouse statement compiler with the ClickHouse dialect so dialect-specific SQL fragments select the correct branch.

--- a/packages/sql/clickhouse/src/ClickhouseClient.ts
+++ b/packages/sql/clickhouse/src/ClickhouseClient.ts
@@ -518,7 +518,7 @@ const typeFromUnknown = (value: unknown): string => {
  */
 export const makeCompiler = (transform?: (_: string) => string) =>
   Statement.makeCompiler<ClickhouseCustom>({
-    dialect: "sqlite",
+    dialect: "clickhouse",
     placeholder(i, u) {
       return `{p${i}: ${typeFromUnknown(u)}}`
     },

--- a/packages/sql/clickhouse/test/Client.test.ts
+++ b/packages/sql/clickhouse/test/Client.test.ts
@@ -34,6 +34,21 @@ describe("ClickhouseClient", { concurrent: false }, () => {
     assert.strictEqual(query, "SELECT {p1: Float64}")
   })
 
+  it("uses the ClickHouse dialect for dialect-specific fragments", () => {
+    const sql = Statement.make(Effect.void as any, ClickhouseClient.makeCompiler(), [], undefined)
+
+    assert.strictEqual(
+      sql.onDialect({
+        sqlite: () => "sqlite",
+        pg: () => "pg",
+        mysql: () => "mysql",
+        mssql: () => "mssql",
+        clickhouse: () => "clickhouse"
+      }),
+      "clickhouse"
+    )
+  })
+
   it.effect("closes the client when the connection check times out", () =>
     Effect.gen(function*() {
       connectImmediately = false


### PR DESCRIPTION
## Summary

Mark the ClickHouse statement compiler with the ClickHouse dialect.

The compiler previously identified itself as `sqlite`, which caused `sql.onDialect(...)` and `sql.onDialectOrElse(...)` to select SQLite branches for ClickHouse clients. The compiler already provides ClickHouse-specific placeholders and escaping; this change corrects the dialect marker used for dialect-specific fragments.


## Reviewer guide

- Compiler dialect selection — [ClickhouseClient.ts:L519-L535](https://github.com/Effect-TS/effect/blob/1749884cd1af25d344ab5e3461333b5b413bdc4d/packages/sql/clickhouse/src/ClickhouseClient.ts#L519-L535) — Verify the compiler remains ClickHouse-specific while exposing the correct dialect marker.
- Dialect dispatch regression test — [Client.test.ts:L37-L50](https://github.com/Effect-TS/effect/blob/1749884cd1af25d344ab5e3461333b5b413bdc4d/packages/sql/clickhouse/test/Client.test.ts#L37-L50) — Verify ClickHouse-specific branches are selected by `onDialect`.

## Testing

- `pnpm lint-fix`
- `pnpm test --run packages/sql/clickhouse/test/Client.test.ts` (5 tests passed)
- `pnpm check`

## Risks

Low. This corrects the compiler metadata used by dialect dispatch. Existing ClickHouse-specific placeholder and identifier callbacks are unchanged.

## Release notes

Included a patch changeset for `@effect/sql-clickhouse`.

